### PR TITLE
Fixed loading bug introduced in 20a2b6

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
@@ -1040,6 +1040,14 @@ public class TPCCLoader extends Loader{
 			} // end for [w]
 
 			LOG.debug("  Writing final records " + k + " of " + t);
+			if (outputFiles == false) {
+			    ordrPrepStmt.executeBatch();
+			    nworPrepStmt.executeBatch();
+			    orlnPrepStmt.executeBatch();
+			} else {
+			    outLine.close();
+			    outNewOrder.close();
+			}
 			transCommit();
 			now = new java.util.Date();
 			LOG.debug("End Orders Load @  " + now);


### PR DESCRIPTION
Hi,

while refactoring TPCC-Loader I introduced a bug, where orders weren't commited after loading (See #14). This fixes it. 

On a (mostly) unrealted note: is this "outputFiles" stuff ever used? Maybe it could be removed to make the code more readable?
