### PR TITLE
More extensive raw output

### DIFF
--- a/src/com/oltpbenchmark/LatencyRecord.java
+++ b/src/com/oltpbenchmark/LatencyRecord.java
@@ -28,9 +28,9 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 	static final int BLOCK_SIZE = 262144;
 
 	/**
-	 * Contains (start time, latency, transactionType) triplets in microsecond
-	 * form. The start times are "compressed" by encoding them as increments,
-	 * starting from startNs. A 32-bit integer provides sufficient resolution
+	 * Contains (start time, latency, transactionType, workerid, phaseid) pentiplets 
+	 * in microsecond form. The start times are "compressed" by encoding them as 
+	 * increments, starting from startNs. A 32-bit integer provides sufficient resolution
 	 * for an interval of 2146 seconds, or 35 minutes.
 	 */
 	// TODO: Use a real variable length encoding?
@@ -49,12 +49,12 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 
 	}
 
-	public void addLatency(int transType, long startNs, long endNs) {
+	public void addLatency(int transType, long startNs, long endNs, int workerId, int phaseId) {
 		assert lastNs > 0;
 		assert lastNs - 500 <= startNs;
 		assert endNs >= startNs;
 
-		if (nextIndex >= BLOCK_SIZE - 3) { // barzan: I changed this!
+		if (nextIndex >= BLOCK_SIZE - 5) { // barzan: I changed this!
 			allocateChunk();
 		}
 		long[] chunk = values.get(values.size() - 1);
@@ -67,14 +67,16 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 		chunk[nextIndex] = transType;
 		chunk[nextIndex + 1] = startOffsetUs;
 		chunk[nextIndex + 2] = latencyUs;
-		nextIndex += 3;
+		chunk[nextIndex + 3] = workerId;
+		chunk[nextIndex + 4] = phaseId;
+		nextIndex += 5;
 
 		lastNs += startOffsetUs * 1000L;
 	}
 
 	private void allocateChunk() {
 		assert (values.isEmpty() && nextIndex == 0)
-				|| nextIndex >= BLOCK_SIZE - 3;
+				|| nextIndex >= BLOCK_SIZE - 5;
 		values.add(new long[BLOCK_SIZE]);
 		nextIndex = 0;
 	}
@@ -82,7 +84,7 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 	/** Returns the number of recorded samples. */
 	public int size() {
 		// Samples stored in full chunks
-		int samples = (values.size() - 1) * (BLOCK_SIZE / 3);
+		int samples = (values.size() - 1) * (BLOCK_SIZE / 5);
 
 		// Samples stored in the last not full chunk
 		samples += nextIndex / 2;
@@ -94,11 +96,15 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 		public final int tranType;
 		public final long startNs;
 		public final int latencyUs;
+		public final int workerId;
+		public final int phaseId;
 
-		public Sample(int tranType, long startNs, int latencyUs) {
+		public Sample(int tranType, long startNs, int latencyUs, int workerId, int phaseId) {
 			this.tranType = tranType;
 			this.startNs = startNs;
 			this.latencyUs = latencyUs;
+			this.workerId = workerId;
+			this.phaseId = phaseId;
 		}
 
 		@Override
@@ -143,15 +149,17 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 			int tranType = (int) chunk[subIndex];
 			long offsetUs = chunk[subIndex + 1];
 			int latencyUs = (int) chunk[subIndex + 2];
-			subIndex += 3;
-			if (subIndex >= BLOCK_SIZE - 3) {
+			int workerId = (int) chunk[subIndex + 3];
+			int phaseId = (int) chunk[subIndex + 4];
+			subIndex += 5;
+			if (subIndex >= BLOCK_SIZE - 5) {
 				chunkIndex += 1;
 				subIndex = 0;
 			}
 
 			long startNs = lastIteratorNs + offsetUs * 1000L;
 			lastIteratorNs = startNs;
-			return new Sample(tranType, startNs, latencyUs);
+			return new Sample(tranType, startNs, latencyUs, workerId, phaseId);
 		}
 
 		@Override

--- a/src/com/oltpbenchmark/Phase.java
+++ b/src/com/oltpbenchmark/Phase.java
@@ -8,6 +8,7 @@ import java.util.Random;
 public class Phase {
 
     private final Random gen = new Random();
+    public final int id;
     public final int time;
     public final int rate;
 
@@ -19,11 +20,12 @@ public class Phase {
     private int activeTerminals;
     
 
-    Phase(int t, int r, List<String> o, boolean rateLimited, boolean disabled, int activeTerminals) {
+    Phase(int id, int t, int r, List<String> o, boolean rateLimited, boolean disabled, int activeTerminals) {
         ArrayList<Double> w = new ArrayList<Double>();
         for (String s : o)
             w.add(Double.parseDouble(s));
 
+        this.id = id;
         this.time = t;
         this.rate = r;
         this.weights = Collections.unmodifiableList(w);

--- a/src/com/oltpbenchmark/Results.java
+++ b/src/com/oltpbenchmark/Results.java
@@ -116,10 +116,10 @@ public final class Results {
         double offset = x - y;
 
         // long startNs = latencySamples.get(0).startNs;
-        out.println("transaction type (index in config file), start time (microseconds),latency (microseconds)");
+        out.println("transaction type (index in config file), start time (microseconds),latency (microseconds),worker id(start number), phase id(index in config file)");
         for (Sample s : latencySamples) {
             double startUs = ((double) s.startNs / (double) 1000000000);
-            out.println(s.tranType + "," + String.format("%10.6f", startUs - offset) + "," + s.latencyUs);
+            out.println(s.tranType + "," + String.format("%10.6f", startUs - offset) + "," + s.latencyUs + "," + s.workerId + "," + s.phaseId);
         }
     }
 

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -73,7 +73,7 @@ public class WorkloadConfiguration {
 	private boolean recordAbortMessages = false;
 
 	public void addWork(int time, int rate, List<String> weights, boolean rateLimited, boolean disabled, int active_terminals) {
-		works.add(new Phase(time, rate, weights, rateLimited, disabled, active_terminals));
+		works.add(new Phase(numberOfPhases, time, rate, weights, rateLimited, disabled, active_terminals));
 		numberOfPhases++;
 	}
 

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -209,7 +209,7 @@ public abstract class Worker implements Runnable {
 			
 			if (measure && type !=null) {
 				long end = System.nanoTime();
-				latencies.addLatency(type.getId(), start, end);
+				latencies.addLatency(type.getId(), start, end, this.id, phase.id);
 			}
 			state = testState.getState();
 		}


### PR DESCRIPTION
Hi,

this changes adds "worker id" and "phase number" to the raw output of a test run. Especially the phase information is important imho, since there is no way at all to tell, when a phase ends (it can run for quite a while after the time runs out, if the queries a long enough). 

The worker id can be used to determine the throughput of a single worker for example.
