### PR TITLE
GPLv3 LICENCE file added

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+oltpbenchmark.com
+ 
+Project Info:  http://oltpbenchmark.com
+Project Members:  	
+					Carlo Curino <carlo.curino@gmail.com>
+					Evan Jones <ej@evanjones.ca>
+					DIFALLAH Djellel Eddine <djelleleddine.difallah@unifr.ch>			
+					Andy Pavlo <pavlo@cs.brown.edu>
+					CUDRE-MAUROUX Philippe <philippe.cudre-mauroux@unifr.ch>  
+					Yang Zhang <yaaang@gmail.com> 
+ 
+This library is free software; you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation;
+either version 3.0 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.


### PR DESCRIPTION
Hi,

although SOME files have a GPL header, there is no LICENCE file in the project. I'm not clear on the specifics, but I think it can't hurt to have one (github parses it automatically, as far as I know, too).

Please check if project member and copyright information is correct, pulled it from one of the headers.

Also, should a copy of GPL be included into the project?
