### PR TITLE
Added option to set random warehouse mode for tpcc workers

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.log4j.Logger;
 
 
@@ -39,9 +40,15 @@ import com.oltpbenchmark.util.SimpleSystemPrinter;
 
 public class TPCCBenchmark extends BenchmarkModule {
     private static final Logger LOG = Logger.getLogger(TPCCBenchmark.class);
+    // Defines if the workers are bound to a warehouse or may randomly choose
+    // one for each transaction
+    private boolean randomWorkerWarehouse = false;
 
 	public TPCCBenchmark(WorkloadConfiguration workConf) {
 		super("tpcc", workConf, true);
+		
+		XMLConfiguration xml = workConf.getXmlConfig();
+		randomWorkerWarehouse = xml.getBoolean("tpcc_random_warehouse", randomWorkerWarehouse);
 	}
 
 	@Override
@@ -59,7 +66,12 @@ public class TPCCBenchmark extends BenchmarkModule {
 		ArrayList<Worker> workers = new ArrayList<Worker>();
 
 		try {
-			List<TPCCWorker> terminals = createTerminals();
+		    List<TPCCWorker> terminals;
+		    if (randomWorkerWarehouse) {
+		        terminals = createRandomClients();
+		    } else {
+		        terminals = createTerminals();
+		    }
 			workers.addAll(terminals);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -71,6 +83,31 @@ public class TPCCBenchmark extends BenchmarkModule {
 	@Override
 	protected Loader makeLoaderImpl(Connection conn) throws SQLException {
 		return new TPCCLoader(this, conn);
+	}
+	
+	/**
+	 * Creates a set of TPC-C workers which are not bound to the a
+	 * individual warehouse or district and generate a warehouse 
+	 * number on each transaction
+	 * @return list of client workers
+	 * @throws SQLException
+	 */
+	protected ArrayList<TPCCWorker> createRandomClients() throws SQLException {
+	    int numWarehouses = (int) workConf.getScaleFactor();
+	    int numClients = workConf.getTerminals();
+	    
+	    LOG.info(String.format("Creating %d dynamic TPC-C clients working on %d warehouses",
+	            numClients, numWarehouses));
+	    
+	    ArrayList<TPCCWorker> ret = new ArrayList<TPCCWorker>();
+	    for (int clientID = 0; clientID < numClients; clientID++) {
+	        String clientName = "Random TPC-C client " + clientID;
+	        TPCCWorker client = new TPCCWorker(clientName, this,
+	                new SimpleSystemPrinter(null), new SimpleSystemPrinter(null),
+	                numWarehouses);
+	        ret.add(client);
+	    }
+	    return ret;
 	}
 
 	protected ArrayList<TPCCWorker> createTerminals() throws SQLException {

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -44,6 +44,10 @@ import com.oltpbenchmark.types.TransactionStatus;
 import com.oltpbenchmark.util.SimplePrinter;
 
 public class TPCCWorker extends Worker {
+    
+    // indicates that the warehouse is not defined and should be chosen
+    // randomly
+    private static final int RANDOM_WH_ID = -1;
 
 	// private TransactionTypes transactionTypes;
 
@@ -60,6 +64,15 @@ public class TPCCWorker extends Worker {
 	private int transactionCount = 1, numWarehouses;
 
 	private static final AtomicInteger terminalId = new AtomicInteger(0);
+	
+	public TPCCWorker(String terminalName, TPCCBenchmark benchmarkModule,
+	        SimplePrinter terminalOutputArea, SimplePrinter errorOutputArea,
+	        int numWarehouses) throws SQLException {
+	    this(terminalName, RANDOM_WH_ID, 1, jTPCCConfig.configDistPerWhse,
+	            benchmarkModule, terminalOutputArea,
+	            errorOutputArea, numWarehouses);
+	    
+	}
 
 	public TPCCWorker(String terminalName, int terminalWarehouseID,
 			int terminalDistrictLowerID, int terminalDistrictUpperID,
@@ -86,9 +99,15 @@ public class TPCCWorker extends Worker {
 	 */
 	@Override
     protected TransactionStatus executeWork(TransactionType nextTransaction) throws UserAbortException, SQLException {
+	    int queryWarehouseID;
+	    if (terminalWarehouseID == RANDOM_WH_ID) {
+	        queryWarehouseID = gen.nextInt(numWarehouses) + 1;
+	    } else {
+	        queryWarehouseID = terminalWarehouseID;
+	    }
         try {
             TPCCProcedure proc = (TPCCProcedure) this.getProcedure(nextTransaction.getProcedureClass());
-            proc.run(conn, gen, terminalWarehouseID, numWarehouses,
+            proc.run(conn, gen, queryWarehouseID, numWarehouses,
                     terminalDistrictLowerID, terminalDistrictUpperID, this);
         } catch (ClassCastException ex){
             //fail gracefully


### PR DESCRIPTION
Hi,

this change adds an optional `tpcc_random_warehouse` parameter to the config, which make the worker choose their warehouse randomly on each transaction.

This TPC-C worker behavior is a part of CH-BenCHmark specification and I've seen it used a couple of times in other TPC-C based benchmarks for in-memory DBMS. Since the CH-BenCHmark would not be complete without it, I would really like for this functionality to be merged. Please, give me feedback if you'd like to change something.

I also think there is a need for an updated documentation for OLTPBenchmark, since the one on http://oltpbenchmark.com weren't updated recently. I could draft one which would contain the recent changes and additions, if you'd tell me, were I should submit it.
