### PR TITLE
Fixed casing error in the CHBenCHmark query 9

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query9.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query9.sql
@@ -16,7 +16,7 @@ WHERE ol_i_id = s_i_id
   AND ol_o_id = o_id
   AND ol_i_id = i_id
   AND su_nationkey = n_nationkey
-  AND i_data LIKE '%BB'
+  AND i_data LIKE '%bb'
 GROUP BY n_name,
          extract(YEAR
                  FROM o_entry_d)


### PR DESCRIPTION
A minor bug which lead to wrong item selection in the query 9.
