### PR TITLE
check to be sure phase is valid before checking its id field

### DIFF
--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -208,7 +208,7 @@ public abstract class Worker implements Runnable {
 //			assert(type != null) :
 //			    "Unexpected null TransactionType returned from doWork\n" + this.transactionTypes;
 			
-			if (measure && type !=null) {
+			if (phase !=null && measure && type !=null) {
 				long end = System.nanoTime();
 				latencies.addLatency(type.getId(), start, end, this.id, phase.id);
 			}


### PR DESCRIPTION
I whipped up a simple benchmark to play around with this code this afternoon (it was pretty trivial, it just loaded a table with 10000 strings and then for the workers, picked an id at random and loaded the string)

I based my benchmark and config off the voter benchmark, and everything seemed to go OK for the minute that it ran. However, when time expired and the benchmark was going to end, it blew up with a Null Pointer Exception in api/Worker.java. In looking at it, it seems that phase was null at the call to addLatency. There's some earlier code that checks for the possibility that phase is null before using it, this adds it again a little later in that same function.

I haven't followed the code enough to see exactly why phase is null and yet measure is True and type is non-null - it's possible/likely that my benchmark doesn't get something right at shutdown time and confuses the benchmark driver back in doWork.

If you're convinced that phase should never be null when it hits that part of the code, please just ignore this pull request. 
