### PR TITLE
LatencyRecord explicitly uses Samples to store results.

### DIFF
--- a/src/com/oltpbenchmark/LatencyRecord.java
+++ b/src/com/oltpbenchmark/LatencyRecord.java
@@ -24,8 +24,8 @@ import java.util.Iterator;
 
 /** Efficiently stores a record of (start time, latency) pairs. */
 public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
-	/** Allocate int[] arrays of this length (262144 = 1 MB). */
-	static final int BLOCK_SIZE = 262144;
+	/** Allocate space for 500k samples at a time */
+	static final int ALLOC_SIZE = 500000;
 
 	/**
 	 * Contains (start time, latency, transactionType, workerid, phaseid) pentiplets 
@@ -33,8 +33,7 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 	 * increments, starting from startNs. A 32-bit integer provides sufficient resolution
 	 * for an interval of 2146 seconds, or 35 minutes.
 	 */
-	// TODO: Use a real variable length encoding?
-	private final ArrayList<long[]> values = new ArrayList<long[]>();
+	private final ArrayList<Sample[]> values = new ArrayList<Sample[]>();
 	private int nextIndex;
 
 	private final long startNs;
@@ -54,47 +53,44 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 		assert lastNs - 500 <= startNs;
 		assert endNs >= startNs;
 
-		if (nextIndex >= BLOCK_SIZE - 5) { // barzan: I changed this!
+		if (nextIndex == ALLOC_SIZE) {
 			allocateChunk();
 		}
-		long[] chunk = values.get(values.size() - 1);
+		Sample[] chunk = values.get(values.size() - 1);
 
-		long startOffsetUs = ((startNs - lastNs + 500) / 1000);
-		assert startOffsetUs >= 0;
+		long startOffsetNs = (startNs - lastNs + 500);
+		assert startOffsetNs >= 0;
 		int latencyUs = (int) ((endNs - startNs + 500) / 1000);
 		assert latencyUs >= 0;
 
-		chunk[nextIndex] = transType;
-		chunk[nextIndex + 1] = startOffsetUs;
-		chunk[nextIndex + 2] = latencyUs;
-		chunk[nextIndex + 3] = workerId;
-		chunk[nextIndex + 4] = phaseId;
-		nextIndex += 5;
+		chunk[nextIndex] = new Sample(transType, startOffsetNs, latencyUs
+				, workerId, phaseId);
+		++nextIndex;
 
-		lastNs += startOffsetUs * 1000L;
+		lastNs += startOffsetNs;
 	}
 
 	private void allocateChunk() {
 		assert (values.isEmpty() && nextIndex == 0)
-				|| nextIndex >= BLOCK_SIZE - 5;
-		values.add(new long[BLOCK_SIZE]);
+			|| nextIndex == ALLOC_SIZE;
+		values.add(new Sample[ALLOC_SIZE]);
 		nextIndex = 0;
 	}
 
 	/** Returns the number of recorded samples. */
 	public int size() {
 		// Samples stored in full chunks
-		int samples = (values.size() - 1) * (BLOCK_SIZE / 5);
+		int samples = (values.size() - 1) * ALLOC_SIZE;
 
 		// Samples stored in the last not full chunk
-		samples += nextIndex / 5;
+		samples += nextIndex;
 		return samples;
 	}
 
 	/** Stores the start time and latency for a single sample. Immutable. */
 	public static final class Sample implements Comparable<Sample> {
 		public final int tranType;
-		public final long startNs;
+		public long startNs;
 		public final int latencyUs;
 		public final int workerId;
 		public final int phaseId;
@@ -145,21 +141,23 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 
 		@Override
 		public Sample next() {
-			long[] chunk = values.get(chunkIndex);
-			int tranType = (int) chunk[subIndex];
-			long offsetUs = chunk[subIndex + 1];
-			int latencyUs = (int) chunk[subIndex + 2];
-			int workerId = (int) chunk[subIndex + 3];
-			int phaseId = (int) chunk[subIndex + 4];
-			subIndex += 5;
-			if (subIndex >= BLOCK_SIZE - 5) {
+			Sample[] chunk = values.get(chunkIndex);
+			Sample s = chunk[subIndex];
+
+			// Iterate in chunk, and wrap to next one
+			++subIndex;
+			assert subIndex <= ALLOC_SIZE;
+			if (subIndex == ALLOC_SIZE) {
 				chunkIndex += 1;
 				subIndex = 0;
 			}
 
-			long startNs = lastIteratorNs + offsetUs * 1000L;
-			lastIteratorNs = startNs;
-			return new Sample(tranType, startNs, latencyUs, workerId, phaseId);
+			// Previously, s.startNs was just an offset from the previous
+			// value.  Now we make it an absolute.
+			s.startNs += lastIteratorNs;
+			lastIteratorNs = s.startNs;
+
+			return s;
 		}
 
 		@Override


### PR DESCRIPTION
See Issue #45.

Explicitly using Samples should make the code more clear (we're storing a collection of record results, that is, a collection of a collection of values---the current code appears at first glance to only be storing a collection of individual values since it uses a long[]). Also, it should make it easier to modify or add record fields.
