### PR TITLE
Closed unclosed PreparedStatements in SEATS FindFlight.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/seats/procedures/FindFlights.java
+++ b/src/com/oltpbenchmark/benchmarks/seats/procedures/FindFlights.java
@@ -187,7 +187,9 @@ public class FindFlights extends Procedure {
                     LOG.debug(String.format("Flight %d / %s /  %s -> %s / %s",
                                             row[0], row[2], row[4], row[9], row[03]));
             } // WHILE
+            ai_stmt.close();
             flightResults.close();
+            f_stmt.close();
         }
         if (debug) {
             LOG.debug("Flight Information:\n" + finalResults);


### PR DESCRIPTION
 Caused errors with SQL Server. Looks like these were missed when the code was reviewed for this issue a couple years ago.
