### PR TITLE
Incremental File Names

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -46,6 +46,7 @@ import com.oltpbenchmark.api.TransactionTypes;
 import com.oltpbenchmark.api.Worker;
 import com.oltpbenchmark.types.DatabaseType;
 import com.oltpbenchmark.util.ClassUtil;
+import com.oltpbenchmark.util.FileUtil;
 import com.oltpbenchmark.util.QueueLimitException;
 import com.oltpbenchmark.util.StringUtil;
 
@@ -402,11 +403,16 @@ public class DBWorkload {
             PrintStream ps = System.out;
             PrintStream rs = System.out;
             if (argsLine.hasOption("o")) {
-                ps = new PrintStream(new File(argsLine.getOptionValue("o") + ".res"));
-                EXEC_LOG.info("Output into file: " + argsLine.getOptionValue("o") + ".res");
+                
+                // Increment the filename for new results
+                String nextName = FileUtil.getNextFilename(argsLine.getOptionValue("o") + ".res");
+                ps = new PrintStream(new File(nextName));
+                EXEC_LOG.info("Output into file: " + nextName);
 
-                rs = new PrintStream(new File(argsLine.getOptionValue("o") + ".raw"));
-                EXEC_LOG.info("Output Raw data into file: " + argsLine.getOptionValue("o") + ".raw");
+                nextName = FileUtil.getNextFilename(argsLine.getOptionValue("o") + ".raw");
+                rs = new PrintStream(new File(nextName));
+                EXEC_LOG.info("Output Raw data into file: " + nextName);
+                
             } else if (EXEC_LOG.isDebugEnabled()) {
                 EXEC_LOG.debug("No output file specified");
             }

--- a/src/com/oltpbenchmark/util/FileUtil.java
+++ b/src/com/oltpbenchmark/util/FileUtil.java
@@ -41,11 +41,43 @@ public abstract class FileUtil {
     private static final Logger LOG = Logger.getLogger(FileUtil.class);
 
     private static final Pattern EXT_SPLIT = Pattern.compile("\\.");
-    
+
+    /**
+     * Given a basename for a file, find the next possible filename if this file
+     * already exists. For example, if the file test.res already exists, create
+     * a file called, test.1.res
+     * 
+     * @param basename
+     * @return
+     */
+    public static String getNextFilename(String basename) {
+        
+        if (!exists(basename))
+            return basename;
+        
+        File f = new File(basename);
+        if (f != null && f.isFile()) {
+            
+            String parts[] = EXT_SPLIT.split(f.getName());
+            
+            // Check how many files already exist
+            int counter = 1;
+            String nextName = parts[0] + "." + counter + "." + parts[1];
+            while(exists(nextName)) {
+                ++counter;
+                nextName = parts[0] + "." + counter + "." + parts[1];
+            }
+            return nextName;
+        }
+
+        // Should we throw instead??
+        return null;
+    }
+
     public static boolean exists(String path) {
         return (new File(path).exists());
     }
-    
+
     public static String realpath(String path) {
         File f = new File(path);
         String ret = null;
@@ -56,29 +88,31 @@ public abstract class FileUtil {
         }
         return (ret);
     }
-    
+
     public static String basename(String path) {
         return (new File(path)).getName();
     }
-    
+
     public static String getExtension(File f) {
         if (f != null && f.isFile()) {
             String parts[] = EXT_SPLIT.split(f.getName());
             if (parts.length > 1) {
-                return (parts[parts.length-1]);
+                return (parts[parts.length - 1]);
             }
         }
         return (null);
-            
+
     }
-    
+
     /**
-     * Create any directory in the list paths if it doesn't exist 
+     * Create any directory in the list paths if it doesn't exist
+     * 
      * @param paths
      */
-    public static void makeDirIfNotExists(String...paths) {
+    public static void makeDirIfNotExists(String... paths) {
         for (String p : paths) {
-            if (p == null) continue;
+            if (p == null)
+                continue;
             File f = new File(p);
             if (f.exists() == false) {
                 f.mkdirs();
@@ -88,35 +122,42 @@ public abstract class FileUtil {
 
     /**
      * Return a File handle to a temporary file location
-     * @param ext the suffix of the filename
-     * @param deleteOnExit whether to delete this file after the JVM exits
+     * 
+     * @param ext
+     *            the suffix of the filename
+     * @param deleteOnExit
+     *            whether to delete this file after the JVM exits
      * @return
      */
     public static File getTempFile(String ext, boolean deleteOnExit) {
         return getTempFile(null, ext, deleteOnExit);
     }
-    
+
     public static File getTempFile(String ext) {
         return (FileUtil.getTempFile(null, ext, false));
     }
-    
+
     public static File getTempFile(String prefix, String suffix, boolean deleteOnExit) {
         File tempFile;
-        if (suffix != null && suffix.startsWith(".") == false) suffix = "." + suffix;
-        if (prefix == null) prefix = "hstore";
-        
+        if (suffix != null && suffix.startsWith(".") == false)
+            suffix = "." + suffix;
+        if (prefix == null)
+            prefix = "hstore";
+
         try {
             tempFile = File.createTempFile(prefix, suffix);
-            if (deleteOnExit) tempFile.deleteOnExit();
+            if (deleteOnExit)
+                tempFile.deleteOnExit();
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
         return (tempFile);
     }
-    
+
     /**
-     * Unsafely create a temporary directory
-     * Yes I said that this was unsafe. I don't care...
+     * Unsafely create a temporary directory Yes I said that this was unsafe. I
+     * don't care...
+     * 
      * @return
      */
     public static File getTempDirectory() {
@@ -128,7 +169,7 @@ public abstract class FileUtil {
         }
         return (temp);
     }
-    
+
     public static File writeStringToFile(String file_path, String content) throws IOException {
         return (FileUtil.writeStringToFile(new File(file_path), content));
     }
@@ -140,20 +181,22 @@ public abstract class FileUtil {
         writer.close();
         return (file);
     }
-    
+
     /**
-     * Write the given string to a temporary file
-     * Will not delete the file after the JVM exits
+     * Write the given string to a temporary file Will not delete the file after
+     * the JVM exits
+     * 
      * @param content
      * @return
      */
     public static File writeStringToTempFile(String content) {
         return (writeStringToTempFile(content, "tmp", false));
     }
-    
+
     /**
-     * Write the given string to a temporary file with the given extension as the suffix
-     * Will not delete the file after the JVM exits
+     * Write the given string to a temporary file with the given extension as
+     * the suffix Will not delete the file after the JVM exits
+     * 
      * @param content
      * @param ext
      * @return
@@ -161,10 +204,12 @@ public abstract class FileUtil {
     public static File writeStringToTempFile(String content, String ext) {
         return (writeStringToTempFile(content, ext, false));
     }
-    
+
     /**
-     * Write the given string to a temporary file with the given extension as the suffix
-     * If deleteOnExit is true, then the file will be removed when the JVM exits
+     * Write the given string to a temporary file with the given extension as
+     * the suffix If deleteOnExit is true, then the file will be removed when
+     * the JVM exits
+     * 
      * @param content
      * @param ext
      * @param deleteOnExit
@@ -173,17 +218,17 @@ public abstract class FileUtil {
     public static File writeStringToTempFile(String content, String ext, boolean deleteOnExit) {
         File tempFile = FileUtil.getTempFile(ext, deleteOnExit);
         try {
-            FileUtil.writeStringToFile(tempFile, content);    
+            FileUtil.writeStringToFile(tempFile, content);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
         return tempFile;
     }
-    
+
     public static String readFile(File path) {
         return (readFile(path.getAbsolutePath()));
     }
-    
+
     public static String readFile(String path) {
         StringBuilder buffer = new StringBuilder();
         try {
@@ -197,10 +242,11 @@ public abstract class FileUtil {
         }
         return (buffer.toString());
     }
-    
+
     /**
-     * Creates a BufferedReader for the given input path
-     * Can handle both gzip and plain text files
+     * Creates a BufferedReader for the given input path Can handle both gzip
+     * and plain text files
+     * 
      * @param path
      * @return
      * @throws IOException
@@ -208,10 +254,11 @@ public abstract class FileUtil {
     public static BufferedReader getReader(String path) throws IOException {
         return (FileUtil.getReader(new File(path)));
     }
-    
+
     /**
-     * Creates a BufferedReader for the given input path
-     * Can handle both gzip and plain text files
+     * Creates a BufferedReader for the given input path Can handle both gzip
+     * and plain text files
+     * 
      * @param file
      * @return
      * @throws IOException
@@ -220,7 +267,7 @@ public abstract class FileUtil {
         if (!file.exists()) {
             throw new IOException("The file '" + file + "' does not exist");
         }
-        
+
         BufferedReader in = null;
         if (file.getPath().endsWith(".gz")) {
             FileInputStream fin = new FileInputStream(file);
@@ -233,21 +280,21 @@ public abstract class FileUtil {
         }
         return (in);
     }
-    
+
     public static byte[] readBytesFromFile(String path) throws IOException {
         File file = new File(path);
         FileInputStream in = new FileInputStream(file);
 
         // Create the byte array to hold the data
         long length = file.length();
-        byte[] bytes = new byte[(int)length];
+        byte[] bytes = new byte[(int) length];
 
         LOG.debug("Reading in the contents of '" + file.getAbsolutePath() + "'");
-        
+
         // Read in the bytes
         int offset = 0;
         int numRead = 0;
-        while ( (offset < bytes.length) && ( (numRead=in.read(bytes, offset, bytes.length-offset)) >= 0) ) {
+        while ((offset < bytes.length) && ((numRead = in.read(bytes, offset, bytes.length - offset)) >= 0)) {
             offset += numRead;
         } // WHILE
         if (offset < bytes.length) {
@@ -256,10 +303,11 @@ public abstract class FileUtil {
         in.close();
         return (bytes);
     }
-    
+
     /**
-     * Find the path to a directory below our current location in the source tree
-     * Throws a RuntimeException if we go beyond our repository checkout
+     * Find the path to a directory below our current location in the source
+     * tree Throws a RuntimeException if we go beyond our repository checkout
+     * 
      * @param dirName
      * @return
      * @throws IOException
@@ -267,10 +315,11 @@ public abstract class FileUtil {
     public static File findDirectory(String dirName) throws IOException {
         return (FileUtil.find(dirName, new File(".").getCanonicalFile(), true).getCanonicalFile());
     }
-    
+
     /**
-     * Find the path to a directory below our current location in the source tree
-     * Throws a RuntimeException if we go beyond our repository checkout
+     * Find the path to a directory below our current location in the source
+     * tree Throws a RuntimeException if we go beyond our repository checkout
+     * 
      * @param dirName
      * @return
      * @throws IOException
@@ -278,34 +327,36 @@ public abstract class FileUtil {
     public static File findFile(String fileName) throws IOException {
         return (FileUtil.find(fileName, new File(".").getCanonicalFile(), false).getCanonicalFile());
     }
-    
+
     private static final File find(String name, File current, boolean isdir) throws IOException {
         LOG.debug("Find Current Location = " + current);
         boolean has_svn = false;
         for (File file : current.listFiles()) {
             if (file.getCanonicalPath().endsWith(File.separator + name) && file.isDirectory() == isdir) {
                 return (file);
-            // Make sure that we don't go to far down...
+                // Make sure that we don't go to far down...
             } else if (file.getCanonicalPath().endsWith(File.separator + ".svn")) {
                 has_svn = true;
             }
         } // FOR
-        // If we didn't see an .svn directory, then we went too far down
+          // If we didn't see an .svn directory, then we went too far down
         if (!has_svn)
-            throw new RuntimeException("Unable to find directory '" + name + "' [last_dir=" + current.getAbsolutePath() + "]");  
+            throw new RuntimeException("Unable to find directory '" + name + "' [last_dir=" + current.getAbsolutePath() + "]");
         File next = new File(current.getCanonicalPath() + File.separator + "..");
         return (FileUtil.find(name, next, isdir));
     }
-    
+
     /**
-     * Returns a list of all the files in a directory whose name starts with the provided prefix
+     * Returns a list of all the files in a directory whose name starts with the
+     * provided prefix
+     * 
      * @param dir
      * @param filePrefix
      * @return
      * @throws IOException
      */
     public static List<File> getFilesInDirectory(final File dir, final String filePrefix) throws IOException {
-        assert(dir.isDirectory()) : "Invalid search directory path: " + dir;
+        assert (dir.isDirectory()) : "Invalid search directory path: " + dir;
         FilenameFilter filter = new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {

--- a/tests/com/oltpbenchmark/util/TestFileUtil.java
+++ b/tests/com/oltpbenchmark/util/TestFileUtil.java
@@ -1,0 +1,55 @@
+package com.oltpbenchmark.util;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.sql.Time;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFileUtil {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+    
+    void touch(String name) {
+        try {
+            File f = new File(name);
+            if (!f.exists())
+                new FileOutputStream(f).close();
+            f.setLastModified(TimeUtil.getCurrentTime().getTime());
+        } catch (IOException e) {}
+    }
+    
+    void rm(String name) {
+        File file = new File(name);
+        file.delete();
+    }
+
+    @Test
+    public void testIncrementFileNames() {
+        
+        String basename = "base.res";
+        assertEquals("base.res", FileUtil.getNextFilename(basename));
+        touch("base.res");
+        assertEquals("base.1.res", FileUtil.getNextFilename(basename));
+        assertEquals("base.1.res", FileUtil.getNextFilename(basename));
+        touch("base.1.res");
+        assertEquals("base.2.res", FileUtil.getNextFilename(basename));
+
+        
+        rm("base.res");
+        rm("base.1.res");
+        rm("base.2.res");
+    }
+
+}


### PR DESCRIPTION
Adding a feature that does not overwrite the results of previous runs when an output file is used using the `-o` option. If the file already exists, it will try in increment given a basename. After base.res follows base.1.res, base.2.res etc.
