### PR TITLE
Adding TravisCI continuous build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+install: echo "Done"
+before_script: echo "Done"
+script: ant junit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OLTPBench
 
+[![Build Status](https://travis-ci.org/oltpbench/oltpbench.png)](https://travis-ci.org/oltpbench/oltpbench)
+
 Benchmarking is incredibly useful, yet endlessly painful. This benchmark suite is the result of a group of
 Phd/post-docs/professors getting together and combining their workloads/frameworks/experiences/efforts. We hope this
 will save other people's time, and will provide an extensible platform, that can be grown in an open-source fashion. 

--- a/build.xml
+++ b/build.xml
@@ -143,7 +143,8 @@
     </macrodef>
     
     <target name="junit"
-            description="Run all test cases for framework.">
+            description="Run all test cases for framework."
+    	    depends="build" >
         <!-- Run the unit tests -->
         <condition property="timeoutLength" value="${timeoutLength}" else='600000'>
             <isset property="timeoutLength"/>


### PR DESCRIPTION
To enable TravisCI CI builds just follow the hook installation from here: http://about.travis-ci.org/docs/user/getting-started/
