### PR TITLE
Adding overridable unload() to Loader class

### DIFF
--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -301,16 +301,12 @@ public abstract class BenchmarkModule {
     public final void clearDatabase() {
         try {
             Connection conn = this.makeConnection();
-            conn.setAutoCommit(false);
-            conn.setTransactionIsolation(workConf.getIsolationMode());
-            Statement st = conn.createStatement();
-            for (Table catalog_tbl : this.catalog.getTables()) {
-                LOG.debug(String.format("Deleting data from %s.%s", workConf.getDBName(), catalog_tbl.getName()));
-                String sql = "DELETE FROM " + catalog_tbl.getEscapedName();
-                st.execute(sql);
-            } // FOR
-            conn.commit();
-
+            Loader loader = this.makeLoaderImpl(conn);
+            if (loader != null) {
+                conn.setAutoCommit(false);
+                loader.unload(this.catalog);
+                conn.commit();
+            }
         } catch (SQLException ex) {
             throw new RuntimeException(String.format("Unexpected error when trying to delete the %s database", this.benchmarkName), ex);
         }

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -35,7 +35,6 @@ import com.oltpbenchmark.util.Histogram;
 import com.oltpbenchmark.util.SQLUtil;
 
 /**
- * 
  * @author pavlo
  */
 public abstract class Loader {
@@ -45,78 +44,101 @@ public abstract class Loader {
     protected final Connection conn;
     protected final WorkloadConfiguration workConf;
     protected final double scaleFactor;
-    private final Histogram<String> tableSizes = new Histogram<String>(true); 
-    
+    private final Histogram<String> tableSizes = new Histogram<String>(true);
+
     public Loader(BenchmarkModule benchmark, Connection conn) {
         this.benchmark = benchmark;
-    	this.conn = conn;
-    	this.workConf = benchmark.getWorkloadConfiguration();
-    	this.scaleFactor = workConf.getScaleFactor();
+        this.conn = conn;
+        this.workConf = benchmark.getWorkloadConfiguration();
+        this.scaleFactor = workConf.getScaleFactor();
     }
-    
+
     public void setTableCount(String tableName, int size) {
         this.tableSizes.set(tableName, size);
     }
-    
+
     public void addToTableCount(String tableName, int delta) {
         this.tableSizes.put(tableName, delta);
     }
-    
+
     public Histogram<String> getTableCounts() {
         return (this.tableSizes);
     }
-    
+
     public DatabaseType getDatabaseType() {
         return (this.workConf.getDBType());
     }
-    
+
     /**
-     * Hackishly return true if we are using the same type as we use in our unit tests
+     * Hackishly return true if we are using the same type as we use in our unit
+     * tests
+     * 
      * @return
      */
     protected final boolean isTesting() {
         return (this.workConf.getDBType() == DatabaseType.TEST_TYPE);
     }
+
     /**
      * Return the database's catalog
      */
     public Catalog getCatalog() {
         return (this.benchmark.getCatalog());
     }
-    
+
     /**
      * Get the catalog object for the given table name
+     * 
      * @param tableName
      * @return
      */
     public Table getTableCatalog(String tableName) {
         Table catalog_tbl = this.benchmark.getCatalog().getTable(tableName.toUpperCase());
-        assert(catalog_tbl != null) : "Invalid table name '" + tableName + "'";
+        assert (catalog_tbl != null) : "Invalid table name '" + tableName + "'";
         return (catalog_tbl);
     }
 
     /**
      * Get the pre-seeded Random generator for this Loader invocation
+     * 
      * @return
      */
     public Random rng() {
-    	return (this.benchmark.rng());
+        return (this.benchmark.rng());
     }
-    
+
     /**
-     * @throws SQLException 
-     * 
+     * @throws SQLException
      */
     public abstract void load() throws SQLException;
-    
-    
-    
+
+    /**
+     * Method that can be overriden to specifically unload the tables of the
+     * database. In the default implementation it checks for tables from the
+     * catalog to delete them using SQL. Any subclass can inject custom behavior
+     * here.
+     * 
+     * @param catalog The catalog containing all loaded tables
+     * @throws SQLException
+     */
+    public void unload(Catalog catalog) throws SQLException {
+        conn.setAutoCommit(false);
+        conn.setTransactionIsolation(workConf.getIsolationMode());
+        Statement st = conn.createStatement();
+        for (Table catalog_tbl : catalog.getTables()) {
+            LOG.debug(String.format("Deleting data from %s.%s", workConf.getDBName(), catalog_tbl.getName()));
+            String sql = "DELETE FROM " + catalog_tbl.getEscapedName();
+            st.execute(sql);
+        } // FOR
+        conn.commit();
+    }
+
     protected void updateAutoIncrement(Column catalog_col, int value) throws SQLException {
         String sql = null;
         switch (getDatabaseType()) {
             case POSTGRES:
                 String seqName = SQLUtil.getSequenceName(getDatabaseType(), catalog_col);
-                assert(seqName != null);
+                assert (seqName != null);
                 sql = String.format("SELECT setval(%s, %d)", seqName.toLowerCase(), value);
                 break;
             default:
@@ -124,8 +146,7 @@ public abstract class Loader {
         }
         if (sql != null) {
             if (LOG.isDebugEnabled())
-                LOG.debug(String.format("Updating %s auto-increment counter with value '%d'",
-                                        catalog_col.fullName(), value));
+                LOG.debug(String.format("Updating %s auto-increment counter with value '%d'", catalog_col.fullName(), value));
             Statement stmt = this.conn.createStatement();
             boolean result = stmt.execute(sql);
             if (LOG.isDebugEnabled())


### PR DESCRIPTION
This patch adds the possibility to manually provide an implementation
for unloading all tables of the benchmark. While the current
implementation uses SQL only, with this patch its possible to override
the method from Loader::unload() and implement own behavior.

The default implementation uses the same behavior as for the loading
of tables via the `makeLoaderImpl` method of the `BenchmarkModule`
