### PR TITLE
New Command Line Options and Sampling Types

### DIFF
--- a/src/com/oltpbenchmark/Results.java
+++ b/src/com/oltpbenchmark/Results.java
@@ -87,13 +87,18 @@ public final class Results {
     }
 
     public void writeCSV(int windowSizeSeconds, PrintStream out) {
-        out.println("time(sec), throughput(req/sec), avg_lat(ms), min_lat(ms), 25th_lat(ms), median_lat(ms), 75th_lat(ms), 90th_lat(ms), 95th_lat(ms), 99th_lat(ms), max_lat(ms)");
+        writeCSV(windowSizeSeconds, out, TransactionType.INVALID);
+    }
+    
+    public void writeCSV(int windowSizeSeconds, PrintStream out, TransactionType txType) {
+        out.println("time(sec), throughput(req/sec), avg_lat(ms), min_lat(ms), 25th_lat(ms), median_lat(ms), 75th_lat(ms), 90th_lat(ms), 95th_lat(ms), 99th_lat(ms), max_lat(ms), tp (req/s) scaled");
         int i = 0;
-        for (DistributionStatistics s : new TimeBucketIterable(latencySamples, windowSizeSeconds)) {
+        for (DistributionStatistics s : new TimeBucketIterable(latencySamples, windowSizeSeconds, txType)) {
             final double MILLISECONDS_FACTOR = 1e3;
-            out.printf("%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n", i * windowSizeSeconds, (double) s.getCount() / windowSizeSeconds, s.getAverage() / MILLISECONDS_FACTOR,
+            out.printf("%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n", i * windowSizeSeconds, (double) s.getCount() / windowSizeSeconds, s.getAverage() / MILLISECONDS_FACTOR,
                     s.getMinimum() / MILLISECONDS_FACTOR, s.get25thPercentile() / MILLISECONDS_FACTOR, s.getMedian() / MILLISECONDS_FACTOR, s.get75thPercentile() / MILLISECONDS_FACTOR,
-                    s.get90thPercentile() / MILLISECONDS_FACTOR, s.get95thPercentile() / MILLISECONDS_FACTOR, s.get99thPercentile() / MILLISECONDS_FACTOR, s.getMaximum() / MILLISECONDS_FACTOR);
+                    s.get90thPercentile() / MILLISECONDS_FACTOR, s.get95thPercentile() / MILLISECONDS_FACTOR, s.get99thPercentile() / MILLISECONDS_FACTOR, s.getMaximum() / MILLISECONDS_FACTOR,
+                    MILLISECONDS_FACTOR / s.getAverage());
             i += 1;
         }
     }

--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -67,30 +67,46 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
     public static final class TimeBucketIterable implements Iterable<DistributionStatistics> {
         private final Iterable<Sample> samples;
         private final int windowSizeSeconds;
+        private final TransactionType txType;
 
-        public TimeBucketIterable(Iterable<Sample> samples, int windowSizeSeconds) {
+        /**
+         * @param samples
+         * @param windowSizeSeconds
+         * @param txType
+         *            Allows to filter transactions by type
+         */
+        public TimeBucketIterable(Iterable<Sample> samples, int windowSizeSeconds, TransactionType txType) {
             this.samples = samples;
             this.windowSizeSeconds = windowSizeSeconds;
+            this.txType = txType;
         }
 
         @Override
         public Iterator<DistributionStatistics> iterator() {
-            return new TimeBucketIterator(samples.iterator(), windowSizeSeconds);
+            return new TimeBucketIterator(samples.iterator(), windowSizeSeconds, txType);
         }
     }
 
     public static final class TimeBucketIterator implements Iterator<DistributionStatistics> {
         private final Iterator<Sample> samples;
         private final int windowSizeSeconds;
+        private final TransactionType txType;
 
         private Sample sample;
         private long nextStartNs;
 
         private DistributionStatistics next;
 
-        public TimeBucketIterator(Iterator<LatencyRecord.Sample> samples, int windowSizeSeconds) {
+        /**
+         * @param samples
+         * @param windowSizeSeconds
+         * @param txType
+         *            Allows to filter transactions by type
+         */
+        public TimeBucketIterator(Iterator<LatencyRecord.Sample> samples, int windowSizeSeconds, TransactionType txType) {
             this.samples = samples;
             this.windowSizeSeconds = windowSizeSeconds;
+            this.txType = txType;
 
             if (samples.hasNext()) {
                 sample = samples.next();
@@ -111,7 +127,12 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             ArrayList<Integer> latencies = new ArrayList<Integer>();
             long endNs = nextStartNs + windowSizeSeconds * 1000000000L;
             while (sample != null && sample.startNs < endNs) {
-                latencies.add(sample.latencyUs);
+
+                // Check if a TX Type filter is set, in the default case,
+                // INVALID TXType means all should be reported, if a filter is
+                // set, only this specific transaction
+                if (txType == TransactionType.INVALID || txType.getId() == sample.tranType)
+                    latencies.add(sample.latencyUs);
 
                 if (samples.hasNext()) {
                     sample = samples.next();
@@ -156,7 +177,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
     }
 
     private void createWorkerThreads() {
-        
+
         for (Worker worker : workers) {
             worker.initializeState();
             Thread thread = new Thread(worker);
@@ -170,9 +191,9 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
     private int finalizeWorkers(ArrayList<Thread> workerThreads) throws InterruptedException {
         assert testState.getState() == State.DONE || testState.getState() == State.EXIT;
         int requests = 0;
-        
+
         new WatchDogThread().start();
-        
+
         for (int i = 0; i < workerThreads.size(); ++i) {
 
             // FIXME not sure this is the best solution... ensure we don't hang
@@ -194,11 +215,12 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
         testState = null;
         return requests;
     }
-    
+
     private class WatchDogThread extends Thread {
         {
             this.setDaemon(true);
         }
+
         @Override
         public void run() {
             Map<String, Object> m = new ListOrderedMap<String, Object>();
@@ -209,7 +231,8 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                 } catch (InterruptedException ex) {
                     return;
                 }
-                if (testState == null) return;
+                if (testState == null)
+                    return;
                 m.clear();
                 for (Thread t : workerThreads) {
                     m.put(t.getName(), t.isAlive());
@@ -235,34 +258,33 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
         assert testState == null;
         testState = new BenchmarkState(workers.size() + 1);
         workStates = new ArrayList<WorkloadState>();
-        
+
         for (WorkloadConfiguration workState : this.workConfs) {
             workStates.add(workState.initializeState(testState));
         }
-        
+
         this.createWorkerThreads();
         testState.blockForStart();
 
         // long measureStart = start;
-        
+
         long start = System.nanoTime();
         long measureEnd = -1;
-        //used to determine the longest sleep interval
+        // used to determine the longest sleep interval
         int lowestRate = Integer.MAX_VALUE;
-        
+
         Phase phase = null;
-        
-        
+
         for (WorkloadState workState : this.workStates) {
-        	workState.switchToNextPhase();
-        	phase = workState.getCurrentPhase();
-        	LOG.info(phase.currentPhaseString());
-        	if (phase.rate < lowestRate) {
-        	    lowestRate = phase.rate;
-        	}
+            workState.switchToNextPhase();
+            phase = workState.getCurrentPhase();
+            LOG.info(phase.currentPhaseString());
+            if (phase.rate < lowestRate) {
+                lowestRate = phase.rate;
+            }
         }
 
-        long intervalNs = getInterval(lowestRate,phase.arrival);
+        long intervalNs = getInterval(lowestRate, phase.arrival);
 
         long nextInterval = start + intervalNs;
         int nextToAdd = 1;
@@ -276,14 +298,14 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
         while (true) {
             // posting new work... and reseting the queue in case we have new
             // portion of the workload...
-            
+
             for (WorkloadState workState : this.workStates) {
                 if (workState.getCurrentPhase() != null) {
                     rateFactor = workState.getCurrentPhase().rate / lowestRate;
                 } else {
                     rateFactor = 1;
                 }
-                    workState.addToQueue(nextToAdd * rateFactor, resetQueues);
+                workState.addToQueue(nextToAdd * rateFactor, resetQueues);
             }
             resetQueues = false;
 
@@ -309,44 +331,44 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                 // reset the queues so that the new phase is not affected by the
                 // queue of the previous one
                 resetQueues = true;
-                
+
                 // Fetch a new Phase
                 synchronized (testState) {
                     for (WorkloadState workState : workStates) {
-                    	workState.switchToNextPhase();
-                    	lowestRate = Integer.MAX_VALUE;
-                    	phase = workState.getCurrentPhase();
-                    	if (phase == null) {
-                    	    // Last phase
-                    	    lastEntry = true;
-                    	    break;
-                    	} else {
-                    	    LOG.info(phase.currentPhaseString());
+                        workState.switchToNextPhase();
+                        lowestRate = Integer.MAX_VALUE;
+                        phase = workState.getCurrentPhase();
+                        if (phase == null) {
+                            // Last phase
+                            lastEntry = true;
+                            break;
+                        } else {
+                            LOG.info(phase.currentPhaseString());
                             if (phase.rate < lowestRate) {
                                 lowestRate = phase.rate;
                             }
-                    	}
+                        }
                     }
                     if (phase != null) {
-                        // update frequency in which we check according to wakeup
+                        // update frequency in which we check according to
+                        // wakeup
                         // speed
-                        // intervalNs = (long) (1000000000. / (double) lowestRate + 0.5);
+                        // intervalNs = (long) (1000000000. / (double)
+                        // lowestRate + 0.5);
                         delta += phase.time * 1000000000L;
                     }
                 }
             }
 
-            // Compute the next interval 
+            // Compute the next interval
             // and how many messages to deliver
-            if(phase != null)
-            {
-                intervalNs=0;
+            if (phase != null) {
+                intervalNs = 0;
                 nextToAdd = 0;
-                do
-                {
-                    intervalNs += getInterval(lowestRate,phase.arrival);
-                    nextToAdd ++;
-                } while ( (-diff) > intervalNs && !lastEntry);
+                do {
+                    intervalNs += getInterval(lowestRate, phase.arrival);
+                    nextToAdd++;
+                } while ((-diff) > intervalNs && !lastEntry);
                 nextInterval += intervalNs;
             }
 
@@ -392,7 +414,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             // Compute transaction histogram
             Set<TransactionType> txnTypes = new HashSet<TransactionType>();
             for (WorkloadConfiguration workConf : workConfs) {
-            	txnTypes.addAll(workConf.getTransTypes());
+                txnTypes.addAll(workConf.getTransTypes());
             }
             txnTypes.remove(TransactionType.INVALID);
 
@@ -400,14 +422,13 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
             results.txnRetry.putAll(txnTypes, 0);
             results.txnAbort.putAll(txnTypes, 0);
             results.txnErrors.putAll(txnTypes, 0);
-            
 
             for (Worker w : workers) {
                 results.txnSuccess.putHistogram(w.getTransactionSuccessHistogram());
                 results.txnRetry.putHistogram(w.getTransactionRetryHistogram());
                 results.txnAbort.putHistogram(w.getTransactionAbortHistogram());
                 results.txnErrors.putHistogram(w.getTransactionErrorHistogram());
-                
+
                 for (Entry<TransactionType, Histogram<String>> e : w.getTransactionAbortMessageHistogram().entrySet()) {
                     Histogram<String> h = results.txnAbortMessages.get(e.getKey());
                     if (h == null) {
@@ -426,220 +447,225 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
 
     private long getInterval(int lowestRate, Phase.Arrival arrival) {
         // TODO Auto-generated method stub
-        if(arrival==Phase.Arrival.POISSON)
-            return (long) ((-Math.log(1-Math.random())/lowestRate) * 1000000000.);
-        else 
+        if (arrival == Phase.Arrival.POISSON)
+            return (long) ((-Math.log(1 - Math.random()) / lowestRate) * 1000000000.);
+        else
             return (long) (1000000000. / (double) lowestRate + 0.5);
     }
 
-//    public Results runPoissonMultiPhase() throws QueueLimitException, IOException {
-//        assert testState == null;
-//        testState = new BenchmarkState(workers.size() + 1);
-//        workStates = new ArrayList<WorkloadState>();
-//        
-//        for (WorkloadConfiguration workState : this.workConfs) {
-//            workStates.add(workState.initializeState(testState));
-//        }
-//        
-//        this.createWorkerThreads();
-//        testState.blockForStart();
-//
-//        long start = System.nanoTime();
-//        long measureEnd = -1;
-//        
-//        //used to determine the longest sleep interval
-//        int lowestRate = Integer.MAX_VALUE;
-//        
-//        Phase phase = null;
-//        
-//        
-//        for (WorkloadState workState : this.workStates) {
-//            workState.switchToNextPhase();
-//            phase = workState.getCurrentPhase();
-//            LOG.info(phase.currentPhaseString());
-//            if (phase.rate < lowestRate) {
-//                lowestRate = phase.rate;
-//            }
-//        }
-//        
-//        long intervalNs = getInterval(lowestRate);
-//        
-//        long nextInterval = start + intervalNs;
-//        int nextToAdd = 1;
-//        int rateFactor;
-//
-//        boolean resetQueues = true;
-//
-//        long delta = phase.time * 1000000000L;
-//        boolean lastEntry = false;
-//        int submitted=0;
-//        while (true) {
-////            System.out.println(intervalNs);
-//            // posting new work... and reseting the queue in case we have new
-//            // portion of the workload...
-//            submitted+=nextToAdd;
-//            for (WorkloadState workState : this.workStates) {
-//                if (workState.getCurrentPhase() != null) {
-//                    rateFactor = workState.getCurrentPhase().rate / lowestRate;
-//                } else {
-//                    rateFactor = 1;
-//                }
-//                    workState.addToQueue(nextToAdd * rateFactor, resetQueues);
-//            }
-//            resetQueues = false;
-//
-//
-//            // Wait until the interval expires, which may be "don't wait"
-//            long now = System.nanoTime();
-//            long diff = nextInterval - now;
-//            while (diff > 0) { // this can wake early: sleep multiple times to
-//                               // avoid that
-//                long ms = diff / 1000000;
-//                diff = diff % 1000000;
-//                try {
-//                    Thread.sleep(ms, (int) diff);
-//                } catch (InterruptedException e) {
-//                    throw new RuntimeException(e);
-//                }
-//                now = System.nanoTime();
-//                diff = nextInterval - now;
-//            }
-//            assert diff <= 0;
-//        
-//            // End of Phase
-//            if (start + delta < System.nanoTime() && !lastEntry) {
-//                // enters here after each phase of the test
-//                // reset the queues so that the new phase is not affected by the
-//                // queue of the previous one
-//                resetQueues = true;
-//                
-//                // Fetch a new Phase
-//                synchronized (testState) {
-//                    for (WorkloadState workState : workStates) {
-//                        workState.switchToNextPhase();
-//                        lowestRate = Integer.MAX_VALUE;
-//                        phase = workState.getCurrentPhase();
-//                        if (phase == null) {
-//                            // Last phase
-//                            lastEntry = true;
-//                            break;
-//                        } else {
-//                            LOG.info(phase.currentPhaseString());
-//                            if (phase.rate < lowestRate) {
-//                                lowestRate = phase.rate;
-//                            }
-//                        }
-//                    }
-//                    if (phase != null) {
-//                        // update frequency in which we check according to wakeup
-//                        // speed
-//                        // intervalNs = (long) (1000000000. / (double) lowestRate + 0.5);
-//                        delta += phase.time * 1000000000L;
-//                    }
-//                }
-//            }
-//            
-//            // Compute the next interval and how many messages to deliver
-//            if(phase != null)
-//            {
-//                intervalNs=0;
-//                nextToAdd = 0;
-//                do
-//                {
-//                    intervalNs += getInterval(lowestRate);;
-//                    nextToAdd ++;
-//                } while ( (-diff) > intervalNs && !lastEntry);
-//                nextInterval += intervalNs;
-//                assert nextToAdd > 0;
-//            }
-//            // Update the test state appropriately
-//            State state = testState.getState();
-//            if (state == State.WARMUP && now >= start) {
-//                testState.startMeasure();
-//                start = now;
-//                // measureEnd = measureStart + measureSeconds * 1000000000L;
-//            } else if (state == State.MEASURE && lastEntry && now >= start + delta) {
-//                System.out.println("### ToTal: "+ submitted);
-//                testState.startCoolDown();
-//                LOG.info("[Terminate] Waiting for all terminals to finish ..");
-//                measureEnd = now;
-//            } else if (state == State.EXIT) {
-//                // All threads have noticed the done, meaning all measured
-//                // requests have definitely finished.
-//                // Time to quit.
-//                break;
-//            }
-//        }
-//        
-//        try {
-//            int requests = finalizeWorkers(this.workerThreads);
-//
-//            // Combine all the latencies together in the most disgusting way
-//            // possible: sorting!
-//            for (Worker w : workers) {
-//                for (LatencyRecord.Sample sample : w.getLatencyRecords()) {
-//                    samples.add(sample);
-//                }
-//            }
-//            Collections.sort(samples);
-//
-//            // Compute stats on all the latencies
-//            int[] latencies = new int[samples.size()];
-//            for (int i = 0; i < samples.size(); ++i) {
-//                latencies[i] = samples.get(i).latencyUs;
-//            }
-//            DistributionStatistics stats = DistributionStatistics.computeStatistics(latencies);
-//
-//            Results results = new Results(measureEnd - start, requests, stats, samples);
-//
-//            // Compute transaction histogram
-//            Set<TransactionType> txnTypes = new HashSet<TransactionType>();
-//            for (WorkloadConfiguration workConf : workConfs) {
-//                txnTypes.addAll(workConf.getTransTypes());
-//            }
-//            txnTypes.remove(TransactionType.INVALID);
-//
-//            results.txnSuccess.putAll(txnTypes, 0);
-//            results.txnRetry.putAll(txnTypes, 0);
-//            results.txnAbort.putAll(txnTypes, 0);
-//            results.txnErrors.putAll(txnTypes, 0);
-//            
-//
-//            for (Worker w : workers) {
-//                results.txnSuccess.putHistogram(w.getTransactionSuccessHistogram());
-//                results.txnRetry.putHistogram(w.getTransactionRetryHistogram());
-//                results.txnAbort.putHistogram(w.getTransactionAbortHistogram());
-//                results.txnErrors.putHistogram(w.getTransactionErrorHistogram());
-//                
-//                for (Entry<TransactionType, Histogram<String>> e : w.getTransactionAbortMessageHistogram().entrySet()) {
-//                    Histogram<String> h = results.txnAbortMessages.get(e.getKey());
-//                    if (h == null) {
-//                        h = new Histogram<String>(true);
-//                        results.txnAbortMessages.put(e.getKey(), h);
-//                    }
-//                    h.putHistogram(e.getValue());
-//                } // FOR
-//            } // FOR
-//
-//            return (results);
-//        } catch (InterruptedException e) {
-//            throw new RuntimeException(e);
-//        }
-//    }
+    // public Results runPoissonMultiPhase() throws QueueLimitException,
+    // IOException {
+    // assert testState == null;
+    // testState = new BenchmarkState(workers.size() + 1);
+    // workStates = new ArrayList<WorkloadState>();
+    //
+    // for (WorkloadConfiguration workState : this.workConfs) {
+    // workStates.add(workState.initializeState(testState));
+    // }
+    //
+    // this.createWorkerThreads();
+    // testState.blockForStart();
+    //
+    // long start = System.nanoTime();
+    // long measureEnd = -1;
+    //
+    // //used to determine the longest sleep interval
+    // int lowestRate = Integer.MAX_VALUE;
+    //
+    // Phase phase = null;
+    //
+    //
+    // for (WorkloadState workState : this.workStates) {
+    // workState.switchToNextPhase();
+    // phase = workState.getCurrentPhase();
+    // LOG.info(phase.currentPhaseString());
+    // if (phase.rate < lowestRate) {
+    // lowestRate = phase.rate;
+    // }
+    // }
+    //
+    // long intervalNs = getInterval(lowestRate);
+    //
+    // long nextInterval = start + intervalNs;
+    // int nextToAdd = 1;
+    // int rateFactor;
+    //
+    // boolean resetQueues = true;
+    //
+    // long delta = phase.time * 1000000000L;
+    // boolean lastEntry = false;
+    // int submitted=0;
+    // while (true) {
+    // // System.out.println(intervalNs);
+    // // posting new work... and reseting the queue in case we have new
+    // // portion of the workload...
+    // submitted+=nextToAdd;
+    // for (WorkloadState workState : this.workStates) {
+    // if (workState.getCurrentPhase() != null) {
+    // rateFactor = workState.getCurrentPhase().rate / lowestRate;
+    // } else {
+    // rateFactor = 1;
+    // }
+    // workState.addToQueue(nextToAdd * rateFactor, resetQueues);
+    // }
+    // resetQueues = false;
+    //
+    //
+    // // Wait until the interval expires, which may be "don't wait"
+    // long now = System.nanoTime();
+    // long diff = nextInterval - now;
+    // while (diff > 0) { // this can wake early: sleep multiple times to
+    // // avoid that
+    // long ms = diff / 1000000;
+    // diff = diff % 1000000;
+    // try {
+    // Thread.sleep(ms, (int) diff);
+    // } catch (InterruptedException e) {
+    // throw new RuntimeException(e);
+    // }
+    // now = System.nanoTime();
+    // diff = nextInterval - now;
+    // }
+    // assert diff <= 0;
+    //
+    // // End of Phase
+    // if (start + delta < System.nanoTime() && !lastEntry) {
+    // // enters here after each phase of the test
+    // // reset the queues so that the new phase is not affected by the
+    // // queue of the previous one
+    // resetQueues = true;
+    //
+    // // Fetch a new Phase
+    // synchronized (testState) {
+    // for (WorkloadState workState : workStates) {
+    // workState.switchToNextPhase();
+    // lowestRate = Integer.MAX_VALUE;
+    // phase = workState.getCurrentPhase();
+    // if (phase == null) {
+    // // Last phase
+    // lastEntry = true;
+    // break;
+    // } else {
+    // LOG.info(phase.currentPhaseString());
+    // if (phase.rate < lowestRate) {
+    // lowestRate = phase.rate;
+    // }
+    // }
+    // }
+    // if (phase != null) {
+    // // update frequency in which we check according to wakeup
+    // // speed
+    // // intervalNs = (long) (1000000000. / (double) lowestRate + 0.5);
+    // delta += phase.time * 1000000000L;
+    // }
+    // }
+    // }
+    //
+    // // Compute the next interval and how many messages to deliver
+    // if(phase != null)
+    // {
+    // intervalNs=0;
+    // nextToAdd = 0;
+    // do
+    // {
+    // intervalNs += getInterval(lowestRate);;
+    // nextToAdd ++;
+    // } while ( (-diff) > intervalNs && !lastEntry);
+    // nextInterval += intervalNs;
+    // assert nextToAdd > 0;
+    // }
+    // // Update the test state appropriately
+    // State state = testState.getState();
+    // if (state == State.WARMUP && now >= start) {
+    // testState.startMeasure();
+    // start = now;
+    // // measureEnd = measureStart + measureSeconds * 1000000000L;
+    // } else if (state == State.MEASURE && lastEntry && now >= start + delta) {
+    // System.out.println("### ToTal: "+ submitted);
+    // testState.startCoolDown();
+    // LOG.info("[Terminate] Waiting for all terminals to finish ..");
+    // measureEnd = now;
+    // } else if (state == State.EXIT) {
+    // // All threads have noticed the done, meaning all measured
+    // // requests have definitely finished.
+    // // Time to quit.
+    // break;
+    // }
+    // }
+    //
+    // try {
+    // int requests = finalizeWorkers(this.workerThreads);
+    //
+    // // Combine all the latencies together in the most disgusting way
+    // // possible: sorting!
+    // for (Worker w : workers) {
+    // for (LatencyRecord.Sample sample : w.getLatencyRecords()) {
+    // samples.add(sample);
+    // }
+    // }
+    // Collections.sort(samples);
+    //
+    // // Compute stats on all the latencies
+    // int[] latencies = new int[samples.size()];
+    // for (int i = 0; i < samples.size(); ++i) {
+    // latencies[i] = samples.get(i).latencyUs;
+    // }
+    // DistributionStatistics stats =
+    // DistributionStatistics.computeStatistics(latencies);
+    //
+    // Results results = new Results(measureEnd - start, requests, stats,
+    // samples);
+    //
+    // // Compute transaction histogram
+    // Set<TransactionType> txnTypes = new HashSet<TransactionType>();
+    // for (WorkloadConfiguration workConf : workConfs) {
+    // txnTypes.addAll(workConf.getTransTypes());
+    // }
+    // txnTypes.remove(TransactionType.INVALID);
+    //
+    // results.txnSuccess.putAll(txnTypes, 0);
+    // results.txnRetry.putAll(txnTypes, 0);
+    // results.txnAbort.putAll(txnTypes, 0);
+    // results.txnErrors.putAll(txnTypes, 0);
+    //
+    //
+    // for (Worker w : workers) {
+    // results.txnSuccess.putHistogram(w.getTransactionSuccessHistogram());
+    // results.txnRetry.putHistogram(w.getTransactionRetryHistogram());
+    // results.txnAbort.putHistogram(w.getTransactionAbortHistogram());
+    // results.txnErrors.putHistogram(w.getTransactionErrorHistogram());
+    //
+    // for (Entry<TransactionType, Histogram<String>> e :
+    // w.getTransactionAbortMessageHistogram().entrySet()) {
+    // Histogram<String> h = results.txnAbortMessages.get(e.getKey());
+    // if (h == null) {
+    // h = new Histogram<String>(true);
+    // results.txnAbortMessages.put(e.getKey(), h);
+    // }
+    // h.putHistogram(e.getValue());
+    // } // FOR
+    // } // FOR
+    //
+    // return (results);
+    // } catch (InterruptedException e) {
+    // throw new RuntimeException(e);
+    // }
+    // }
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-        // Something bad happened! Tell all of our workers that the party is over!
-//        synchronized (this) {
-//            if (this.calledTearDown == false) {
-//                for (Worker w : this.workers) {
-//                    w.tearDown(true);
-//                }
-//            }
-//            this.calledTearDown = true;
-//        } // SYNCH
-//            
-        
+        // Something bad happened! Tell all of our workers that the party is
+        // over!
+        // synchronized (this) {
+        // if (this.calledTearDown == false) {
+        // for (Worker w : this.workers) {
+        // w.tearDown(true);
+        // }
+        // }
+        // this.calledTearDown = true;
+        // } // SYNCH
+        //
+
         // HERE WE HANDLE THE CASE IN WHICH ONE OF OUR WOKERTHREADS DIED
         e.printStackTrace();
         System.exit(-1);

--- a/src/com/oltpbenchmark/util/FileUtil.java
+++ b/src/com/oltpbenchmark/util/FileUtil.java
@@ -41,6 +41,27 @@ public abstract class FileUtil {
     private static final Logger LOG = Logger.getLogger(FileUtil.class);
 
     private static final Pattern EXT_SPLIT = Pattern.compile("\\.");
+    
+    
+    /**
+     * Join path components
+     * @param args
+     * @return
+     */
+    public static String joinPath(String... args) {
+        StringBuilder result = new StringBuilder();
+        boolean first = true;
+        for (String a : args) {
+            if (a != null && a.length() > 0) {
+                if (!first) {
+                    result.append("/");
+                }
+                result.append(a);
+                first = false;
+            }
+        }
+        return result.toString();
+    }
 
     /**
      * Given a basename for a file, find the next possible filename if this file
@@ -57,8 +78,7 @@ public abstract class FileUtil {
         
         File f = new File(basename);
         if (f != null && f.isFile()) {
-            
-            String parts[] = EXT_SPLIT.split(f.getName());
+            String parts[] = EXT_SPLIT.split(basename);
             
             // Check how many files already exist
             int counter = 1;
@@ -69,6 +89,7 @@ public abstract class FileUtil {
             }
             return nextName;
         }
+        
 
         // Should we throw instead??
         return null;


### PR DESCRIPTION
This patch introduces a new more verbose output for results. It allows
to print the sampled version of the output grouped by transaction.
This will create a single file with the name of the transaction and
the default output file name for each transaction.

The new options in summary
- `-ss` - more verbose output, adding samples by transaction
- `-d` - define output directory for the output to avoid cluttering the base directory
- `-t` - prepend timestamp for the output files for more logical sorting and better information recovery
