### PR TITLE
fix incorrect statement preparation in YCSB

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/ycsb/procedures/InsertRecord.java
+++ b/src/com/oltpbenchmark/benchmarks/ycsb/procedures/InsertRecord.java
@@ -33,7 +33,7 @@ public class InsertRecord extends Procedure {
         PreparedStatement stmt = this.getPreparedStatement(conn, this.insertStmt);
         stmt.setInt(1, keyname);
         for (int i = 0; i < vals.length; i++) {
-            stmt.setString(i + 1, vals[i]);
+            stmt.setString(i + 2, vals[i]);
         }
         stmt.executeUpdate();
     }


### PR DESCRIPTION
Attempting to run YCSB results in the following failure (tested only on Postgres, probably fails everywhere):

```
org.postgresql.util.PSQLException: No value specified for parameter 11.
	at org.postgresql.core.v3.SimpleParameterList.checkAllParametersSet(SimpleParameterList.java:226)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:207)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:421)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:137)
	at com.oltpbenchmark.benchmarks.ycsb.procedures.InsertRecord.run(InsertRecord.java:38)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.insertRecord(YCSBWorker.java:136)
	at com.oltpbenchmark.benchmarks.ycsb.YCSBWorker.executeWork(YCSBWorker.java:91)
	at com.oltpbenchmark.api.Worker.doWork(Worker.java:381)
	at com.oltpbenchmark.api.Worker.run(Worker.java:291)
	at java.lang.Thread.run(Thread.java:745)
```

This is because the statement is incorrectly prepared due to an off-by-one error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oltpbenchmark/oltpbench/135)
<!-- Reviewable:end -->
