### PR TITLE
Travis chbenchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,13 +74,11 @@ env:
   - TEST=noop
   - TEST=smallbank
   - TEST=twitter
+  - TEST=chbenchmark
 
 # Missing loader com.oltpbenchmark.benchmarks.resourcestresser.ResourceStresserBenchmark.makeLoaderImpl(ResourceStresserBenchmark.java:58)
 # -> org.apache.commons.lang.NotImplementedException: Code is not implemented
 #  - TEST=resourcestresser
-
-# Missing sample config file
-#  - TEST=chbenchmark
 #
 # Missing sample config
 #  - TEST=hyadapt

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/CHBenCHmark.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/CHBenCHmark.java
@@ -31,12 +31,16 @@ import com.oltpbenchmark.api.Loader;
 import com.oltpbenchmark.api.Worker;
 import com.oltpbenchmark.benchmarks.chbenchmark.queries.Q1;
 import com.oltpbenchmark.benchmarks.tpcc.TPCCConfig;
+import com.oltpbenchmark.benchmarks.tpcc.TPCCBenchmark;
 
 public class CHBenCHmark extends BenchmarkModule {
 	private static final Logger LOG = Logger.getLogger(CHBenCHmark.class);
+
+	public TPCCBenchmark tpccbenchmark;
 	
 	public CHBenCHmark(WorkloadConfiguration workConf) {
 		super("chbenchmark", workConf, true);
+		tpccbenchmark = new TPCCBenchmark(workConf);
 	}
 	
 	protected Package getProcedurePackageImpl() {

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/CHBenCHmarkLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/CHBenCHmarkLoader.java
@@ -36,6 +36,7 @@ import com.oltpbenchmark.benchmarks.chbenchmark.pojo.Nation;
 import com.oltpbenchmark.benchmarks.chbenchmark.pojo.Region;
 import com.oltpbenchmark.benchmarks.chbenchmark.pojo.Supplier;
 import com.oltpbenchmark.util.RandomGenerator;
+import com.oltpbenchmark.benchmarks.tpcc.TPCCLoader;
 
 public class CHBenCHmarkLoader extends Loader<CHBenCHmark> {
 	private static final Logger LOG = Logger.getLogger(CHBenCHmarkLoader.class);
@@ -49,6 +50,8 @@ public class CHBenCHmarkLoader extends Loader<CHBenCHmark> {
 	private static Date now;
 	private static long lastTimeMS;
 	private static Connection conn;
+
+	private static TPCCLoader tpccLoader;
 	
 	//create possible keys for n_nationkey ([a-zA-Z0-9])
 	private static final int[] nationkeys = new int[62];
@@ -67,11 +70,13 @@ public class CHBenCHmarkLoader extends Loader<CHBenCHmark> {
 	public CHBenCHmarkLoader(CHBenCHmark benchmark, Connection c) {
 		super(benchmark, c);
 		conn =c;
+		tpccLoader = new TPCCLoader(benchmark.tpccbenchmark,c);
 	}
 	
 	@Override
 	public List<LoaderThread> createLoaderTheads() throws SQLException {
-	    // TODO Auto-generated method stub
+
+	    tpccLoader.createLoaderTheads();
 	    return null;
 	}
 

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q1.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q1.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q10.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q10.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q11.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q11.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q12.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q12.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q13.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q13.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q14.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q14.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q15.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q15.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q16.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q16.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q17.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q17.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q18.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q18.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q19.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q19.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q2.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q2.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q20.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q20.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q21.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q21.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q22.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q22.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q3.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q3.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q4.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q4.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q5.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q5.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q6.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q6.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q7.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q7.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q8.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q8.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q9.java
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/Q9.java
@@ -1,14 +1,14 @@
 /******************************************************************************
  *  Copyright 2015 by OLTPBenchmark Project                                   *
  *                                                                            *
- *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  Licensed under the Apache License, Version 2.0 (the License);             *
  *  you may not use this file except in compliance with the License.          *
  *  You may obtain a copy of the License at                                   *
  *                                                                            *
  *    http://www.apache.org/licenses/LICENSE-2.0                              *
  *                                                                            *
  *  Unless required by applicable law or agreed to in writing, software       *
- *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  distributed under the License is distributed on an AS IS BASIS,           *
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
  *  See the License for the specific language governing permissions and       *
  *  limitations under the License.                                            *

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/extract_queries.py
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/extract_queries.py
@@ -8,7 +8,7 @@ import re
 import sqlparse
 
 if __name__ == "__main__":
-    for x in xrange(1, 23):
+    for x in range(1, 23):
         with open("Q{0}.java".format(x), "r") as java_file:
             with open("query{0}.sql".format(x), "w") as query_file:
                 sql = "".join(re.findall('\"(.*?)\"', java_file.read()))

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query1.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query1.sql
@@ -7,4 +7,4 @@ SELECT ol_number,
 FROM order_line
 WHERE ol_delivery_d > '2007-01-02 00:00:00.000000'
 GROUP BY ol_number
-ORDER BY ol_number;
+ORDER BY ol_number

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query10.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query10.sql
@@ -16,10 +16,12 @@ WHERE c_id = o_c_id
   AND ol_o_id = o_id
   AND o_entry_d >= '2007-01-02 00:00:00.000000'
   AND o_entry_d <= ol_delivery_d
-  AND n_nationkey = ascii(substring(c_state from  1  for  1))
+  AND n_nationkey = ascii(substring(c_state
+                                    FROM 1
+                                    FOR 1))
 GROUP BY c_id,
          c_last,
          c_city,
          c_phone,
          n_name
-ORDER BY revenue DESC;
+ORDER BY revenue DESC

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query11.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query11.sql
@@ -6,7 +6,8 @@ FROM stock,
 WHERE mod((s_w_id * s_i_id), 10000) = su_suppkey
   AND su_nationkey = n_nationkey
   AND n_name = 'Germany'
-GROUP BY s_i_id HAVING sum(s_order_cnt) >
+GROUP BY s_i_id
+HAVING sum(s_order_cnt) >
   (SELECT sum(s_order_cnt) * .005
    FROM stock,
         supplier,
@@ -14,4 +15,4 @@ GROUP BY s_i_id HAVING sum(s_order_cnt) >
    WHERE mod((s_w_id * s_i_id), 10000) = su_suppkey
      AND su_nationkey = n_nationkey
      AND n_name = 'Germany')
-ORDER BY ordercount DESC;
+ORDER BY ordercount DESC

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query12.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query12.sql
@@ -1,8 +1,14 @@
 SELECT o_ol_cnt,
-       sum(CASE WHEN o_carrier_id = 1
-           OR o_carrier_id = 2 THEN 1 ELSE 0 END) AS high_line_count,
-       sum(CASE WHEN o_carrier_id <> 1
-           AND o_carrier_id <> 2 THEN 1 ELSE 0 END) AS low_line_count
+       sum(CASE
+               WHEN o_carrier_id = 1
+                    OR o_carrier_id = 2 THEN 1
+               ELSE 0
+           END) AS high_line_count,
+       sum(CASE
+               WHEN o_carrier_id <> 1
+                    AND o_carrier_id <> 2 THEN 1
+               ELSE 0
+           END) AS low_line_count
 FROM oorder,
      order_line
 WHERE ol_w_id = o_w_id
@@ -11,4 +17,4 @@ WHERE ol_w_id = o_w_id
   AND o_entry_d <= ol_delivery_d
   AND ol_delivery_d < '2020-01-01 00:00:00.000000'
 GROUP BY o_ol_cnt
-ORDER BY o_ol_cnt;
+ORDER BY o_ol_cnt

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query13.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query13.sql
@@ -10,4 +10,5 @@ FROM
                               AND o_carrier_id > 8)
    GROUP BY c_id) AS c_orders
 GROUP BY c_count
-ORDER BY custdist DESC, c_count DESC;
+ORDER BY custdist DESC,
+         c_count DESC

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query14.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query14.sql
@@ -1,6 +1,9 @@
-SELECT (100.00 * sum(CASE WHEN i_data LIKE 'PR%' THEN ol_amount ELSE 0 END) / (1 + sum(ol_amount))) AS promo_revenue
+SELECT (100.00 * sum(CASE
+                         WHEN i_data LIKE 'PR%' THEN ol_amount
+                         ELSE 0
+                     END) / (1 + sum(ol_amount))) AS promo_revenue
 FROM order_line,
      item
 WHERE ol_i_id = i_id
   AND ol_delivery_d >= '2007-01-02 00:00:00.000000'
-  AND ol_delivery_d < '2020-01-02 00:00:00.000000';
+  AND ol_delivery_d < '2020-01-02 00:00:00.000000'

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query15.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query15.sql
@@ -1,9 +1,20 @@
-SELECT su_suppkey,
-       su_name,
-       su_address,
-       su_phone,
-       total_revenue
-FROM supplier, revenue0
+CREATE VIEW revenue0 (supplier_no, total_revenue) AS
+SELECT mod((s_w_id * s_i_id),10000) AS supplier_no,
+       sum(ol_amount) AS total_revenue
+FROM order_line,
+     stock
+WHERE ol_i_id = s_i_id
+  AND ol_supply_w_id = s_w_id
+  AND ol_delivery_d >= '2007-01-02 00:00:00.000000'
+GROUP BY supplier_noSELECT su_suppkey,
+         su_name,
+         su_address,
+         su_phone,
+         total_revenue
+FROM supplier,
+     revenue0
 WHERE su_suppkey = supplier_no
-    AND total_revenue = (select max(total_revenue) from revenue0)
-ORDER BY su_suppkey;
+  AND total_revenue =
+    (SELECT max(total_revenue)
+     FROM revenue0)
+ORDER BY su_suppkeyDROP VIEW revenue0

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query16.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query16.sql
@@ -1,5 +1,7 @@
 SELECT i_name,
-       substring(i_data from  1 for 3) AS brand,
+       substring(i_data
+                 FROM 1
+                 FOR 3) AS brand,
        i_price,
        count(DISTINCT (mod((s_w_id * s_i_id),10000))) AS supplier_cnt
 FROM stock,
@@ -7,10 +9,10 @@ FROM stock,
 WHERE i_id = s_i_id
   AND i_data NOT LIKE 'zz%'
   AND (mod((s_w_id * s_i_id),10000) NOT IN
-    (SELECT su_suppkey
-     FROM supplier
-     WHERE su_comment LIKE '%bad%'))
+         (SELECT su_suppkey
+          FROM supplier
+          WHERE su_comment LIKE '%bad%'))
 GROUP BY i_name,
          brand,
          i_price
-ORDER BY supplier_cnt DESC;
+ORDER BY supplier_cnt DESC

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query17.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query17.sql
@@ -1,10 +1,12 @@
-SELECT SUM (ol_amount) / 2.0 AS avg_yearly
+SELECT SUM(ol_amount) / 2.0 AS avg_yearly
 FROM order_line,
-  (SELECT i_id, AVG (ol_quantity) AS a
+
+  (SELECT i_id,
+          AVG (ol_quantity) AS a
    FROM item,
         order_line
    WHERE i_data LIKE '%b'
      AND ol_i_id = i_id
    GROUP BY i_id) t
 WHERE ol_i_id = t.i_id
-  AND ol_quantity < t.a;
+  AND ol_quantity < t.a

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query18.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query18.sql
@@ -19,5 +19,7 @@ GROUP BY o_id,
          c_id,
          c_last,
          o_entry_d,
-         o_ol_cnt HAVING sum(ol_amount) > 200
-ORDER BY amount_sum DESC, o_entry_d;
+         o_ol_cnt
+HAVING sum(ol_amount) > 200
+ORDER BY amount_sum DESC,
+         o_entry_d

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query19.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query19.sql
@@ -24,4 +24,4 @@ WHERE (ol_i_id = i_id
       AND i_price BETWEEN 1 AND 400000
       AND ol_w_id IN (1,
                       5,
-                      3));
+                      3))

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query2.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query2.sql
@@ -6,19 +6,25 @@ SELECT su_suppkey,
        su_address,
        su_phone,
        su_comment
-FROM item, supplier, stock, nation, region,
-  (SELECT s_i_id AS m_i_id, MIN (s_quantity) AS m_s_quantity
+FROM item,
+     supplier,
+     stock,
+     nation,
+     region,
+
+  (SELECT s_i_id AS m_i_id,
+          MIN(s_quantity) AS m_s_quantity
    FROM stock,
         supplier,
         nation,
         region
-   WHERE MOD ((s_w_id*s_i_id), 10000)=su_suppkey
+   WHERE MOD((s_w_id*s_i_id), 10000)=su_suppkey
      AND su_nationkey=n_nationkey
      AND n_regionkey=r_regionkey
      AND r_name LIKE 'Europ%'
    GROUP BY s_i_id) m
 WHERE i_id = s_i_id
-  AND MOD ((s_w_id * s_i_id), 10000) = su_suppkey
+  AND MOD((s_w_id * s_i_id), 10000) = su_suppkey
   AND su_nationkey = n_nationkey
   AND n_regionkey = r_regionkey
   AND i_data LIKE '%b'
@@ -27,4 +33,4 @@ WHERE i_id = s_i_id
   AND s_quantity = m_s_quantity
 ORDER BY n_name,
          su_name,
-         i_id;
+         i_id

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query20.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query20.sql
@@ -11,7 +11,8 @@ WHERE su_suppkey IN
        AND i_data LIKE 'co%'
      GROUP BY s_i_id,
               s_w_id,
-              s_quantity HAVING 2*s_quantity > sum(ol_quantity))
+              s_quantity
+     HAVING 2*s_quantity > sum(ol_quantity))
   AND su_nationkey = n_nationkey
   AND n_name = 'Germany'
-ORDER BY su_name;
+ORDER BY su_name

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query21.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query21.sql
@@ -22,4 +22,5 @@ WHERE ol_o_id = o_id
   AND su_nationkey = n_nationkey
   AND n_name = 'Germany'
 GROUP BY su_name
-ORDER BY numwait DESC, su_name;
+ORDER BY numwait DESC,
+         su_name

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query22.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query22.sql
@@ -1,30 +1,38 @@
-SELECT substring(c_state from 1 for 1) AS country,
-count(*) AS numcust,
-sum(c_balance) AS totacctbal
+SELECT substring(c_state
+                 FROM 1
+                 FOR 1) AS country,
+       count(*) AS numcust,
+       sum(c_balance) AS totacctbal
 FROM customer
-WHERE substring(c_phone from 1 for 1) IN ('1',
-                              '2',
-                              '3',
-                              '4',
-                              '5',
-                              '6',
-                              '7')
+WHERE substring(c_phone
+                FROM 1
+                FOR 1) IN ('1',
+                           '2',
+                           '3',
+                           '4',
+                           '5',
+                           '6',
+                           '7')
   AND c_balance >
     (SELECT avg(c_balance)
      FROM customer
      WHERE c_balance > 0.00
-       AND substring(c_phone from 1 for 1) IN ('1',
-                                   '2',
-                                   '3',
-                                   '4',
-                                   '5',
-                                   '6',
-                                   '7'))
+       AND substring(c_phone
+                     FROM 1
+                     FOR 1) IN ('1',
+                                '2',
+                                '3',
+                                '4',
+                                '5',
+                                '6',
+                                '7'))
   AND NOT EXISTS
     (SELECT *
      FROM oorder
      WHERE o_c_id = c_id
        AND o_w_id = c_w_id
        AND o_d_id = c_d_id)
-GROUP BY substring(c_state from 1 for 1)
-ORDER BY substring(c_state,1,1);
+GROUP BY substring(c_state
+                   FROM 1
+                   FOR 1)
+ORDER BY substring(c_state,1,1)

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query3.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query3.sql
@@ -22,4 +22,5 @@ GROUP BY ol_o_id,
          ol_w_id,
          ol_d_id,
          o_entry_d
-ORDER BY revenue DESC , o_entry_d
+ORDER BY revenue DESC,
+         o_entry_d

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query4.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query4.sql
@@ -1,7 +1,7 @@
 SELECT o_ol_cnt,
        count(*) AS order_count
 FROM oorder
-WHERE exists
+WHERE EXISTS
     (SELECT *
      FROM order_line
      WHERE o_id = ol_o_id

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query5.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query5.sql
@@ -15,11 +15,13 @@ WHERE c_id = o_c_id
   AND ol_d_id=o_d_id
   AND ol_w_id = s_w_id
   AND ol_i_id = s_i_id
-  AND MOD ((s_w_id * s_i_id), 10000) = su_suppkey
-  AND ascii(substring(c_state from  1  for  1)) = su_nationkey
+  AND MOD((s_w_id * s_i_id), 10000) = su_suppkey
+  AND ascii(substring(c_state
+                      FROM 1
+                      FOR 1)) = su_nationkey
   AND su_nationkey = n_nationkey
   AND n_regionkey = r_regionkey
   AND r_name = 'Europe'
   AND o_entry_d >= '2007-01-02 00:00:00.000000'
 GROUP BY n_name
-ORDER BY revenue DESC;
+ORDER BY revenue DESC

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query7.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query7.sql
@@ -1,5 +1,7 @@
 SELECT su_nationkey AS supp_nation,
-       substring(c_state from 1 for 1) AS cust_nation,
+       substring(c_state
+                 FROM 1
+                 FOR 1) AS cust_nation,
        extract(YEAR
                FROM o_entry_d) AS l_year,
        sum(ol_amount) AS revenue
@@ -20,7 +22,9 @@ WHERE ol_supply_w_id = s_w_id
   AND c_w_id = o_w_id
   AND c_d_id = o_d_id
   AND su_nationkey = n1.n_nationkey
-  AND ascii(substring(c_state from  1  for  1)) = n2.n_nationkey
+  AND ascii(substring(c_state
+                      FROM 1
+                      FOR 1)) = n2.n_nationkey
   AND ((n1.n_name = 'Germany'
         AND n2.n_name = 'Cambodia')
        OR (n1.n_name = 'Cambodia'

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query8.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query8.sql
@@ -1,6 +1,9 @@
 SELECT extract(YEAR
                FROM o_entry_d) AS l_year,
-       sum(CASE WHEN n2.n_name = 'Germany' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share
+       sum(CASE
+               WHEN n2.n_name = 'Germany' THEN ol_amount
+               ELSE 0
+           END) / sum(ol_amount) AS mkt_share
 FROM item,
      supplier,
      stock,
@@ -20,7 +23,9 @@ WHERE i_id = s_i_id
   AND c_id = o_c_id
   AND c_w_id = o_w_id
   AND c_d_id = o_d_id
-  AND n1.n_nationkey = ascii(substring(c_state from  1  for  1))
+  AND n1.n_nationkey = ascii(substring(c_state
+                                       FROM 1
+                                       FOR 1))
   AND n1.n_regionkey = r_regionkey
   AND ol_i_id < 1000
   AND r_name = 'Europe'
@@ -28,4 +33,4 @@ WHERE i_id = s_i_id
   AND i_data LIKE '%b'
   AND i_id = ol_i_id
 GROUP BY l_year
-ORDER BY l_year;
+ORDER BY l_year

--- a/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query9.sql
+++ b/src/com/oltpbenchmark/benchmarks/chbenchmark/queries/query9.sql
@@ -20,4 +20,4 @@ WHERE ol_i_id = s_i_id
 GROUP BY n_name,
          l_year
 ORDER BY n_name,
-         l_year DESC;
+         l_year DESC


### PR DESCRIPTION
I tried to use the TPCCLoader to create the missing tables.

This isn't quite correct yet.

As per travis output some tables aren't created/loaded:
- stock
- customer
- revenue0
- order_line
- oorder
- ...
