### PR TITLE
Travis: use older image for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 sudo: required
+group: deprecated-2017Q2
 
 # lib contains jar files to support running tests
 cache:


### PR DESCRIPTION
Travis just updated their Ubuntu Trusty images and our junit tests no longer pass. I've updated travis.yml to use the older image until I have time to look into this.