### PR TITLE
hotfix TATPLoader: itemsPerThread must be at least 1

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tatp/TATPLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/tatp/TATPLoader.java
@@ -46,7 +46,7 @@ public class TATPLoader extends Loader<TATPBenchmark> {
     public List<LoaderThread> createLoaderThreads() throws SQLException {
         List<LoaderThread> threads = new ArrayList<LoaderThread>();
         final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
-        final long itemsPerThread = this.subscriberSize / numLoaders;
+        final long itemsPerThread = Long.max(this.subscriberSize / numLoaders, 1);
         final int numSubThreads = (int) Math.ceil((double) this.subscriberSize / itemsPerThread);
         final CountDownLatch subLatch = new CountDownLatch(numSubThreads);
 


### PR DESCRIPTION
Previously it was possible to have a division by zero when subscriberSize < numLoaders, generating +inf.

```
        final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
        final long itemsPerThread = this.subscriberSize / numLoaders;
        final int numSubThreads = (int) Math.ceil((double) this.subscriberSize / itemsPerThread);
```