### PR TITLE
fix Epinions and Wikipedia Loaders: itemsPerThread calculations

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/epinions/EpinionsLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/epinions/EpinionsLoader.java
@@ -61,7 +61,7 @@ public class EpinionsLoader extends Loader<EpinionsBenchmark> {
         List<LoaderThread> threads = new ArrayList<LoaderThread>();
         final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
         final int numToLoad = this.num_items + this.num_users;
-        final int loadPerThread = numToLoad / numLoaders;
+        final int loadPerThread = Math.max(numToLoad / numLoaders, 1);
         final int numUserThreads = (int) Math.ceil((double) this.num_users / loadPerThread);
         final int numItemThreads = (int) Math.ceil((double) this.num_items / loadPerThread);
 

--- a/src/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/wikipedia/WikipediaLoader.java
@@ -109,7 +109,7 @@ public class WikipediaLoader extends Loader<WikipediaBenchmark> {
         List<LoaderThread> threads = new ArrayList<LoaderThread>();
         final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
         final int numItems = this.num_pages + this.num_users;
-        final int itemsPerThread = numItems / numLoaders;
+        final int itemsPerThread = Math.max(numItems / numLoaders, 1);
         final int numUserThreads = (int) Math.ceil((double) this.num_users / itemsPerThread);
         final int numPageThreads = (int) Math.ceil((double) this.num_pages / itemsPerThread);
 


### PR DESCRIPTION
We should ensure that itemsPerThread is always at least 1 to avoid division by zero.