### PR TITLE
fix ZipfianGenerator: should not return 0 or 1

### DIFF
--- a/src/com/oltpbenchmark/distributions/ZipfianGenerator.java
+++ b/src/com/oltpbenchmark/distributions/ZipfianGenerator.java
@@ -289,12 +289,12 @@ public class ZipfianGenerator extends IntegerGenerator
 
 		if (uz<1.0)
 		{
-			return 0;
+			return base;
 		}
 
 		if (uz<1.0+Math.pow(0.5,theta)) 
 		{
-			return 1;
+			return base + 1;
 		}
 
 		long ret=base+(long)((itemcount) * Math.pow(eta*u - eta + 1, alpha));


### PR DESCRIPTION
Yahoo fixed this bug in their ZipfianGenerator in https://github.com/brianfrankcooper/YCSB/commit/149ea82959276c1151902158f3f9b376188dc8be

Previously, ZipfianGenerator.nextX() had a chance of returning 0 or 1 regardless of what its min and max values were.