### PR TITLE
Multi-threaded SIBench

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/sibench/SILoader.java
+++ b/src/com/oltpbenchmark/benchmarks/sibench/SILoader.java
@@ -44,50 +44,50 @@ public class SILoader extends Loader<SIBenchmark> {
     @Override
     public List<LoaderThread> createLoaderThreads() throws SQLException {
         List<LoaderThread> threads = new ArrayList<LoaderThread>();
+        final int numLoaders = this.benchmark.getWorkloadConfiguration().getLoaderThreads();
+        final int itemsPerThread = Math.max(this.num_record / numLoaders, 1);
+        final int numRecordThreads = (int) Math.ceil((double) this.num_record / itemsPerThread);
 
-        threads.add(new LoaderThread() {
-            @Override
-            public void load(Connection conn) throws SQLException {
-                SILoader.this.loadData(conn);
-            }
-        });
+        // SITEST
+        for (int i = 0; i < numRecordThreads; i++) {
+            final int lo = i * itemsPerThread + 1;
+            final int hi = Math.min(this.num_record, (i + 1) * itemsPerThread);
+
+            threads.add(new LoaderThread() {
+                @Override
+                public void load(Connection conn) throws SQLException {
+                    SILoader.this.loadSITest(conn, lo, hi);
+                }
+            });
+        }
 
         return threads;
     }
 
-    private void loadData(Connection conn) throws SQLException {
+    private void loadSITest(Connection conn, int lo, int hi) throws SQLException {
         Random rand = this.benchmark.rng();
         Table catalog_tbl = this.benchmark.getTableCatalog("SITEST");
         assert (catalog_tbl != null);
 
         String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
         PreparedStatement stmt = conn.prepareStatement(sql);
-        long total = 0;
         int batch = 0;
-        for (int i = 1; i <= this.num_record; i++) {
+        for (int i = lo; i <= hi; i++) {
             stmt.setInt(1, i);
             stmt.setInt(2, rand.nextInt(Integer.MAX_VALUE));
             stmt.addBatch();
-            total++;
+
             if (++batch >= SIConstants.configCommitCount) {
                 int result[] = stmt.executeBatch();
                 assert (result != null);
                 conn.commit();
                 batch = 0;
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(String.format("Records Loaded %d / %d", total, this.num_record));
-                }
             }
         } // FOR
         if (batch > 0) {
             stmt.executeBatch();
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Records Loaded %d / %d", total, this.num_record));
-            }
+            conn.commit();
         }
         stmt.close();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Finished loading " + catalog_tbl.getName());
-        }
     }
 }

--- a/src/com/oltpbenchmark/benchmarks/sibench/SILoader.java
+++ b/src/com/oltpbenchmark/benchmarks/sibench/SILoader.java
@@ -19,13 +19,13 @@ package com.oltpbenchmark.benchmarks.sibench;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import org.apache.log4j.Logger;
 
 import com.oltpbenchmark.api.Loader;
-import com.oltpbenchmark.api.Loader.LoaderThread;
 import com.oltpbenchmark.catalog.Table;
 import com.oltpbenchmark.util.SQLUtil;
 
@@ -40,24 +40,31 @@ public class SILoader extends Loader<SIBenchmark> {
             LOG.debug("# of RECORDS:  " + this.num_record);
         }
     }
-    
-    @Override
-    public List<LoaderThread> createLoaderThreads() throws SQLException {
-        // TODO Auto-generated method stub
-        return null;
-    }
 
     @Override
-    public void load() throws SQLException {
+    public List<LoaderThread> createLoaderThreads() throws SQLException {
+        List<LoaderThread> threads = new ArrayList<LoaderThread>();
+
+        threads.add(new LoaderThread() {
+            @Override
+            public void load(Connection conn) throws SQLException {
+                SILoader.this.loadData(conn);
+            }
+        });
+
+        return threads;
+    }
+
+    private void loadData(Connection conn) throws SQLException {
         Random rand = this.benchmark.rng();
         Table catalog_tbl = this.benchmark.getTableCatalog("SITEST");
         assert (catalog_tbl != null);
-        
+
         String sql = SQLUtil.getInsertSQL(catalog_tbl, this.getDatabaseType());
-        PreparedStatement stmt = this.conn.prepareStatement(sql);
+        PreparedStatement stmt = conn.prepareStatement(sql);
         long total = 0;
         int batch = 0;
-        for (int i = 0; i < this.num_record; i++) {
+        for (int i = 1; i <= this.num_record; i++) {
             stmt.setInt(1, i);
             stmt.setInt(2, rand.nextInt(Integer.MAX_VALUE));
             stmt.addBatch();
@@ -67,16 +74,20 @@ public class SILoader extends Loader<SIBenchmark> {
                 assert (result != null);
                 conn.commit();
                 batch = 0;
-                if (LOG.isDebugEnabled())
+                if (LOG.isDebugEnabled()) {
                     LOG.debug(String.format("Records Loaded %d / %d", total, this.num_record));
+                }
             }
         } // FOR
         if (batch > 0) {
             stmt.executeBatch();
-            if (LOG.isDebugEnabled())
+            if (LOG.isDebugEnabled()) {
                 LOG.debug(String.format("Records Loaded %d / %d", total, this.num_record));
+            }
         }
         stmt.close();
-        if (LOG.isDebugEnabled()) LOG.debug("Finished loading " + catalog_tbl.getName());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Finished loading " + catalog_tbl.getName());
+        }
     }
 }


### PR DESCRIPTION
Straightforward conversion. Removed the debug log since the information doesn't make much sense when run with multiple threads. Also converted to 1-indexing.