### PR TITLE
Possibly fix TravisCI randomly failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,11 @@ services:
   - mysql
 
 install:
+  # ancient travis issue, ensure stdout is blocking
+  # otherwise builds may (or may not!) fail with large stdout writes
+  # https://github.com/travis-ci/travis-ci/issues/8902
+  # https://github.com/travis-ci/travis-ci/issues/4704
+  - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
   - echo $TRAVIS_JDK_VERSION
   - if [ $TRAVIS_JDK_VERSION == oraclejdk8 ]; then
       DB=mysql ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ script:
            -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
            -e '/<username>/c\<username>travis</username>'
            -e '/<password>/c\<password>travis</password>'
-           -e '/<scalefactor>/c\<scalefactor>0.5</scalefactor>'
+           -e '/<scalefactor>/c\<scalefactor>0.3</scalefactor>'
            -e '/<terminals>/c\<terminals>3</terminals>'
            -e '/<time>/c\<time>60</time>'
            -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'


### PR DESCRIPTION
We currently experience similar issues to https://github.com/travis-ci/travis-ci/issues/8902, where tests randomly fail.
Since December, many other projects have recently experienced similar issues.

https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959 fixed their problem.

The problem was writing too much to stdout with nonblocking IO.

Right now we're having issues with Wikipedia.
I notice we're printing out a histogram whose length depends on table size;
and if the RNG gives us large table sizes then we'll print out more.
This may fix it.
