### PR TITLE
Temporary Travis hack: Wikipedia scalefactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ script:
            -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
            -e '/<username>/c\<username>travis</username>'
            -e '/<password>/c\<password>travis</password>'
-           -e '/<scalefactor>/c\<scalefactor>${SCALEFACTOR}</scalefactor>'
+           -e "/<scalefactor>/c\\<scalefactor>${SCALEFACTOR}</scalefactor>"
            -e '/<terminals>/c\<terminals>3</terminals>'
            -e '/<time>/c\<time>60</time>'
            -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,9 +130,26 @@ before_script:
       TYPE=postgres ;
     fi
 
+# As of 2018-01-10, Travis is running into space issues with ramfs
+# So we're special casing our larger benchmarks to use lower scalefactor
 script:
   - if [ $TEST == junit ]; then
       ant junit;
+    elif [ $TEST == wikipedia ]; then
+      ant build;
+      config=config/sample_${TEST}_config.xml ;
+      sed -i
+           -e "/<dbtype>/c\<dbtype>${TYPE}</dbtype>"
+           -e "/<driver>/c\<driver>${DRIVER}</driver>"
+           -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
+           -e '/<username>/c\<username>travis</username>'
+           -e '/<password>/c\<password>travis</password>'
+           -e '/<scalefactor>/c\<scalefactor>0.25</scalefactor>'
+           -e '/<terminals>/c\<terminals>3</terminals>'
+           -e '/<time>/c\<time>60</time>'
+           -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'
+           "${config}";
+      ./oltpbenchmark --bench "${TEST}" --config "${config}"  --create true    --load true   --execute true ;
     else
       ant build;
       config=config/sample_${TEST}_config.xml ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ before_script:
 script:
   - SCALEFACTOR=0.5
   - if [ $TEST == wikipedia ]; then
-      SCALEFACTOR=0.25
+      SCALEFACTOR=0.25 ;
     fi
   - if [ $TEST == junit ]; then
       ant junit;

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,23 +133,12 @@ before_script:
 # As of 2018-01-10, Travis is running into space issues with ramfs
 # So we're special casing our larger benchmarks to use lower scalefactor
 script:
+  - SCALEFACTOR=0.5
+  - if [ $TEST == wikipedia ]; then
+      SCALEFACTOR=0.25
+    fi
   - if [ $TEST == junit ]; then
       ant junit;
-    elif [ $TEST == wikipedia ]; then
-      ant build;
-      config=config/sample_${TEST}_config.xml ;
-      sed -i
-           -e "/<dbtype>/c\<dbtype>${TYPE}</dbtype>"
-           -e "/<driver>/c\<driver>${DRIVER}</driver>"
-           -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
-           -e '/<username>/c\<username>travis</username>'
-           -e '/<password>/c\<password>travis</password>'
-           -e '/<scalefactor>/c\<scalefactor>0.25</scalefactor>'
-           -e '/<terminals>/c\<terminals>3</terminals>'
-           -e '/<time>/c\<time>60</time>'
-           -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'
-           "${config}";
-      ./oltpbenchmark --bench "${TEST}" --config "${config}"  --create true    --load true   --execute true ;
     else
       ant build;
       config=config/sample_${TEST}_config.xml ;
@@ -159,7 +148,7 @@ script:
            -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
            -e '/<username>/c\<username>travis</username>'
            -e '/<password>/c\<password>travis</password>'
-           -e '/<scalefactor>/c\<scalefactor>0.5</scalefactor>'
+           -e '/<scalefactor>/c\<scalefactor>${SCALEFACTOR}</scalefactor>'
            -e '/<terminals>/c\<terminals>3</terminals>'
            -e '/<time>/c\<time>60</time>'
            -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'


### PR DESCRIPTION
Travis appears to be having issues with ramfs, which causes our larger benchmarks to fail sometimes.

See: 
- https://github.com/travis-ci/travis-ci/issues/9036
- https://github.com/travis-ci/travis-ci/issues/8902 
- https://github.com/travis-ci/travis-ci/issues/4704

Until this is resolved, we can hack around it by using a smaller scalefactor for Wikipedia (and any other large benchmarks that have similar issues).