### PR TITLE
fix BenchmarkModule: support spaces in filepath to dialects file

### DIFF
--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -19,6 +19,7 @@ package com.oltpbenchmark.api;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -226,9 +227,15 @@ public abstract class BenchmarkModule {
         };
         for(String xmlName : xmlNames) { 
             URL ddlURL = this.getClass().getResource( DIALECTS_DIR + File.separator + xmlName);
-            if (ddlURL != null) return new File(ddlURL.getPath());
-                if (LOG.isDebugEnabled())
-                    LOG.warn(String.format("Failed to find SQL Dialect XML file '%s'", xmlName));
+            if (ddlURL != null) {
+                try {
+                    return new File(ddlURL.toURI().getPath());
+                } catch (URISyntaxException e) {
+                    e.printStackTrace();
+                    if (LOG.isDebugEnabled())
+                        LOG.warn(String.format("Failed to find SQL Dialect XML file '%s'", xmlName));
+                }
+            }
         }
         return (null);
     }


### PR DESCRIPTION
Previously, a path like 
"/Users/xyz/Google Drive/.../...-dialects.xml"
would attempt to load
"/Users/xyz/Google%20Drive/.../...-dialects.xml"