### PR TITLE
Remove junit:check from build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -148,9 +148,7 @@
                 showoutput="@{showoutput}"
             >
                 <classpath refid='project.classpath' />
-                <jvmarg value="-Djava.library.path=${build.dir}/nativelibs" />
                 <jvmarg value="-server" />
-                <jvmarg value="-Xcheck:jni" />
                 <jvmarg value="-Xmx2048m"/>
                 <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError"/>
                 


### PR DESCRIPTION
Remove junit:check from build.xml so that when running `ant junit` it doesn't flood the console of warn messages.

Fixes #235