### PR TITLE
Fixed Postgres metrics collection

### DIFF
--- a/src/com/oltpbenchmark/api/collectors/PostgresCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/PostgresCollector.java
@@ -19,14 +19,11 @@ package com.oltpbenchmark.api.collectors;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.log4j.Logger;
 
@@ -69,8 +66,12 @@ public class PostgresCollector extends DBCollector {
 
             // Collect DBMS internal metrics
             for (String viewName : PG_STAT_VIEWS) {
-            	out = s.executeQuery("SELECT * FROM " + viewName);
-            	pgMetrics.put(viewName, getMetrics(out));
+            	try {
+            		out = s.executeQuery("SELECT * FROM " + viewName);
+            		pgMetrics.put(viewName, getMetrics(out));
+            	} catch (SQLException ex) {
+            		LOG.error("Error while collecting DB metric view: " + ex.getMessage());
+            	}
             }
         } catch (SQLException e) {
             LOG.error("Error while collecting DB parameters: " + e.getMessage());


### PR DESCRIPTION
Newer versions of Postgres have more statistics views to collect from. The Postgres collector will now print a warning if a given statistics view does not exist and then continue collecting the other available views in order to support older versions.