### PR TITLE
Possible Bug Fix in AuctionMark

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/auctionmark/util/AuctionMarkUtil.java
+++ b/src/com/oltpbenchmark/benchmarks/auctionmark/util/AuctionMarkUtil.java
@@ -66,7 +66,7 @@ public abstract class AuctionMarkUtil {
         // The idx cannot be more than 7bits
         assert(idx >= 0 && idx <= 128) :
             String.format("Invalid element idx %d", idx);
-        long id = ((long) idx << 52) | (item_id & ITEM_ID_MASK);
+        long id = ((long) idx << 56) | (item_id & ITEM_ID_MASK);
         assert(id >= 0) :
             String.format("Invalid negative element id %d [item_id=%d, idx=%d]",
                           id, item_id, idx);


### PR DESCRIPTION
getUniqueElementId(item_id, idx) seems to be incorrectly left shifting idx by 52 to merge it into item_id. The least significant 56 bits of item_id are in use (see auctionmark/util/ItemId.java).
Replaced with left shift idx by 56.

I am getting duplicate primary key constraint violations for the NewItem transaction because of this:

14:52:22,347 (Worker.java:492) WARN  - The DBMS rejected the transaction without an error code
com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Duplicate entry '6000035131555841-6000035131555841-178782209' for key 'PRIMARY'
        at sun.reflect.GeneratedConstructorAccessor8.newInstance(Unknown Source)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at com.mysql.jdbc.Util.handleNewInstance(Util.java:411)
        at com.mysql.jdbc.Util.getInstance(Util.java:386)
        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:1040)
        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:4096)
        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:4028)
        at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2490)
        at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2651)
        at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2734)
        at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:2155)
        at com.mysql.jdbc.PreparedStatement.executeUpdate(PreparedStatement.java:2458)
        at com.mysql.jdbc.PreparedStatement.executeUpdate(PreparedStatement.java:2375)
        at com.mysql.jdbc.PreparedStatement.executeUpdate(PreparedStatement.java:2359)
        at com.oltpbenchmark.benchmarks.auctionmark.procedures.NewItem.run(NewItem.java:273)
        at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeNewItem(AuctionMarkWorker.java:788)
        at com.oltpbenchmark.benchmarks.auctionmark.AuctionMarkWorker.executeWork(AuctionMarkWorker.java:387)
        at com.oltpbenchmark.api.Worker.doWork(Worker.java:386)
        at com.oltpbenchmark.api.Worker.run(Worker.java:296)
        at java.lang.Thread.run(Thread.java:748)
