### PR TITLE
Postgres: handle memory error

### DIFF
--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -457,6 +457,9 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     } else if (ex.getErrorCode() == 0 && ex.getSQLState() != null && ex.getSQLState().equals("53200")) {
                         // Postgres OOM error
                         throw ex;
+                    } else if (ex.getErrorCode() == 0 && ex.getSQLState() != null && ex.getSQLState().equals("XX000")) {
+                        // Postgres no pinned buffers available
+                        throw ex;
                         
                     // ------------------
                     // ORACLE


### PR DESCRIPTION
Throw an exception if we encounter a "no pinned buffers available" error from Postgres because it's non-recoverable.