### PR TITLE
Mistake in i_data and s_data checks

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
@@ -335,8 +335,8 @@ public class NewOrder extends TPCCProcedure {
 				orderLineAmounts[ol_number - 1] = ol_amount;
 				total_amount += ol_amount;
 
-				if (i_data.indexOf("GENERIC") != -1
-						&& s_data.indexOf("GENERIC") != -1) {
+				if (i_data.indexOf("ORIGINAL") != -1
+						&& s_data.indexOf("ORIGINAL") != -1) {
 					brandGeneric[ol_number - 1] = 'B';
 				} else {
 					brandGeneric[ol_number - 1] = 'G';


### PR DESCRIPTION
According to [TPC-C document ](http://www.tpc.org/tpc_documents_current_versions/pdf/tpc-c_v5.11.0.pdf)(page 30):

> The strings in I_DATA and S_DATA are examined. If they both include the string "ORIGINAL", the brand-generic field for that item is set to "B", otherwise, the brand-generic field is set to "G".

I also checked the database tables populated using oltpbench tool and it contains rows with "ORIGINAL"  like byrnvnyaycxwcqukjjhtusqqksnfwysjhORIGINAL.

I am assuming "GENERIC" is a mistake.