### PR TITLE
Clean up result output and add command-line opts to control it

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -21,8 +21,8 @@
 	<dependencies>
       <!-- JDBC Drivers -->
 		<dependency org="org.xerial" name="sqlite-jdbc" rev="3.6.20" force="true" conf="test->compile(*),runtime(*),master(*)"/>
-		<dependency org="org.postgresql" name="postgresql" rev="9.4.1209" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
-		<dependency org="mysql" name="mysql-connector-java" rev="5.1.47"/>
+		<dependency org="org.postgresql" name="postgresql" rev="42.2.6" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="mysql" name="mysql-connector-java" rev="8.0.16"/>
 		<dependency org="org.hsqldb" name="hsqldb" rev="2.4.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 
       <!-- Core Libraries -->

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -18,6 +18,7 @@
 package com.oltpbenchmark;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -44,6 +46,7 @@ import com.oltpbenchmark.api.BenchmarkModule;
 import com.oltpbenchmark.api.TransactionType;
 import com.oltpbenchmark.api.TransactionTypes;
 import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.api.collectors.DBCollector;
 import com.oltpbenchmark.types.DatabaseType;
 import com.oltpbenchmark.util.ClassUtil;
 import com.oltpbenchmark.util.FileUtil;
@@ -61,6 +64,9 @@ public class DBWorkload {
     private static final String RATE_DISABLED = "disabled";
     private static final String RATE_UNLIMITED = "unlimited";
     
+    private static final String DEFAULT_RESULT_DIRECTORY = "results";
+    private static final String DEFAULT_RESULT_FILENAME = "oltpbench";
+
     /**
      * @param args
      * @throws Exception 
@@ -587,12 +593,11 @@ public class DBWorkload {
 
             // WRITE OUTPUT
             writeOutputs(r, activeTXTypes, argsLine, benchList.get(0).getWorkloadConfiguration());
-            
+
             // WRITE HISTOGRAMS
             if (argsLine.hasOption("histograms")) {
                 writeHistograms(r);
             }
-
 
         } else {
             LOG.info("Skipping benchmark workload execution");
@@ -631,8 +636,7 @@ public class DBWorkload {
         LOG.info("Workload Histograms:\n" + sb.toString());
         LOG.info(SINGLE_LINE);
     }
-    
-        
+
     /**
      * Write out the results for a benchmark run to a bunch of files
      * @param r
@@ -642,140 +646,165 @@ public class DBWorkload {
      * @throws Exception
      */
     private static void writeOutputs(Results r, List<TransactionType> activeTXTypes, CommandLine argsLine,
-            WorkloadConfiguration wkldConfig) throws Exception {
-        
-        // If an output directory is used, store the information
-        String outputDirectory = "results";
-        if (argsLine.hasOption("d")) {
-            outputDirectory = argsLine.getOptionValue("d");
-        }
-        String filePrefix = "";
-        if (argsLine.hasOption("t")) {
-            filePrefix = String.valueOf(TimeUtil.getCurrentTime().getTime()) + "_";
-        }
-        
-        // Special result uploader
-        XMLConfiguration xmlConfig = wkldConfig.getXmlConfig();
-        ResultUploader ru = null;
-        if (xmlConfig.containsKey("uploadUrl")) {
-            ru = new ResultUploader(r, wkldConfig, argsLine);
-            LOG.info("Upload Results URL: " + ru);
-        }
-        
-        // Output target 
+            WorkloadConfiguration workConf) throws Exception {
+
+        boolean outputToFile; // Whether to output results to file or stdout
         PrintStream ps = null;
-        PrintStream rs = null;
-        String baseFileName = "oltpbench";
-        if (argsLine.hasOption("o")) {
-            if (argsLine.getOptionValue("o").equals("-")) {
-                ps = System.out;
-                rs = System.out;
-                baseFileName = null;
-            } else {
-                baseFileName = argsLine.getOptionValue("o");
+
+        String baseFileName = argsLine.getOptionValue("o", DEFAULT_RESULT_FILENAME);
+        if (baseFileName.equals("-")) {
+            outputToFile = false;
+            ps = System.out;
+            baseFileName = null;
+            LOG.debug("Printing all requested results to stdout");
+
+        } else {
+            assert (baseFileName != null);
+            outputToFile = true;
+
+            String outputDirectory = argsLine.getOptionValue("d", DEFAULT_RESULT_DIRECTORY);
+            FileUtil.makeDirIfNotExists(outputDirectory.split("/"));
+
+            // Prepend all output files with a timestamp
+            String filePrefix = "";
+            if (argsLine.hasOption("t")) {
+                filePrefix = String.valueOf(TimeUtil.getCurrentTime().getTime()) + "_";
             }
+            baseFileName = FileUtil.joinPath(outputDirectory, filePrefix + baseFileName);
+            LOG.debug("Saving all requested results to directory: " + outputDirectory);
         }
 
-        // Build the complex path
-        String baseFile = filePrefix;
-        String nextName;
-        
-        if (baseFileName != null) {
-            // Check if directory needs to be created
-            if (outputDirectory.length() > 0) {
-                FileUtil.makeDirIfNotExists(outputDirectory.split("/"));
+        String nextName = null;
+        Map<String, String> resultFiles = new HashMap<String, String>();
+
+        if (isBooleanOptionSet(argsLine, "output-raw")) {
+            // Raw performance results from all transactions
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".csv.gz");
+                ps = new PrintStream(new GZIPOutputStream(new FileOutputStream(nextName)));
+                resultFiles.put("csv", nextName);
+                LOG.info("Saving raw performance data to: " + nextName);
             }
-            
-            baseFile = filePrefix + baseFileName;
+            r.writeAllCSVAbsoluteTiming(activeTXTypes, ps);
+            if (outputToFile)
+                ps.close();
+        }
 
-            if (argsLine.getOptionValue("output-raw", "true").equalsIgnoreCase("true")) {
-                // RAW OUTPUT
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".csv"));
-                rs = new PrintStream(new File(nextName));
-                LOG.info("Output Raw data into file: " + nextName);
-                r.writeAllCSVAbsoluteTiming(activeTXTypes, rs);
-                rs.close();
+        if (isBooleanOptionSet(argsLine, "output-samples")) {
+            // Write samples using 1 second window -- TODO
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".samples");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("samples", nextName);
+                LOG.info("Saving txn samples to: " + nextName);
             }
-
-            if (isBooleanOptionSet(argsLine, "output-samples")) {
-                // Write samples using 1 second window
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".samples"));
-                rs = new PrintStream(new File(nextName));
-                LOG.info("Output samples into file: " + nextName);
-                r.writeCSV2(rs);
-                rs.close();
+            r.writeCSV2(ps);
+            if (outputToFile)
+                ps.close();
+        }
+        if (isBooleanOptionSet(argsLine, "output-bench-config")) {
+            // Benchmark Configuration
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".expconfig");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("expconfig", nextName);
+                LOG.info("Saving benchmark configuration to: " + nextName);
             }
+            ResultUploader.writeBenchmarkConf(workConf.getXmlConfig(), ps);
+            if (outputToFile)
+                ps.close();
+        }
 
-            // Result Uploader Files
-            if (ru != null) {
-                // Summary Data
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".summary"));
-                PrintStream ss = new PrintStream(new File(nextName));
-                LOG.info("Output summary data into file: " + nextName);
-                ru.writeSummary(ss);
-                ss.close();
-
-                // DBMS Parameters
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".params"));
-                ss = new PrintStream(new File(nextName));
-                LOG.info("Output DBMS parameters into file: " + nextName);
-                ru.writeDBParameters(ss);
-                ss.close();
-
-                // DBMS Metrics
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".metrics"));
-                ss = new PrintStream(new File(nextName));
-                LOG.info("Output DBMS metrics into file: " + nextName);
-                ru.writeDBMetrics(ss);
-                ss.close();
-
-                // Experiment Configuration
-                nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".expconfig"));
-                ss = new PrintStream(new File(nextName));
-                LOG.info("Output experiment config into file: " + nextName);
-                ru.writeBenchmarkConf(ss);
-                ss.close();
+        DBCollector dbCollector = null;
+        if (isBooleanOptionSet(argsLine, "output-summary")) {
+            // Summary of workload and performance data
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".summary");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("summary", nextName);
+                LOG.info("Saving benchmark summary to: " + nextName);
             }
-            
-        } else if (LOG.isDebugEnabled()) {
-            LOG.debug("No output file specified");
+            ResultUploader.writeSummary(workConf, r, ps);
+            if (outputToFile) ps.close();
         }
         
-        if (isBooleanOptionSet(argsLine, "upload") && ru != null) {
-            ru.uploadResult(activeTXTypes);
+        if (isBooleanOptionSet(argsLine, "output-dbms-knobs")) {
+            // DBMS configuration settings
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".params");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("params", nextName);
+                LOG.info("Saving DBMS configuration knobs to: " + nextName);
+            }
+            if (dbCollector == null)
+                dbCollector = DBCollector.createCollector(workConf.getDB());
+            ps.println(dbCollector.collectParameters());
+            if (outputToFile) ps.close();
         }
-        
-        // SUMMARY FILE
+
+        if (isBooleanOptionSet(argsLine, "output-dbms-metrics")) {
+            // DBMS runtime metrics
+            if (outputToFile) {
+                nextName = FileUtil.getNextFilename(baseFileName + ".metrics");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("metrics", nextName);
+                LOG.info("Saving DBMS metrics to: " + nextName);
+            }
+            if (dbCollector == null)
+                dbCollector = DBCollector.createCollector(workConf.getDB());
+            ps.println(dbCollector.collectMetrics());
+            if (outputToFile)
+                ps.close();
+        }
+
         if (argsLine.hasOption("s")) {
-            nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".res"));
-            ps = new PrintStream(new File(nextName));
-            LOG.info("Output throughput samples into file: " + nextName);
-            
+            if (outputToFile) {
+                // Sampled transactions
+                nextName = FileUtil.getNextFilename(baseFileName + ".res");
+                ps = new PrintStream(new File(nextName));
+                resultFiles.put("res", nextName);
+                LOG.info("Saving txn samples to: " + nextName);
+            }
             int windowSize = Integer.parseInt(argsLine.getOptionValue("s"));
             LOG.info("Grouped into Buckets of " + windowSize + " seconds");
             r.writeCSV(windowSize, ps);
+            if (outputToFile)
+                ps.close();
 
-            // Allow more detailed reporting by transaction to make it easier to check
+            // More detailed reporting by transaction type to make
             if (argsLine.hasOption("ss")) {
-                
+                String txnFileName;
                 for (TransactionType t : activeTXTypes) {
-                    PrintStream ts = ps;
-                    if (ts != System.out) {
-                        // Get the actual filename for the output
-                        baseFile = filePrefix + baseFileName + "_" + t.getName();
-                        nextName = FileUtil.getNextFilename(FileUtil.joinPath(outputDirectory, baseFile + ".res"));                            
-                        ts = new PrintStream(new File(nextName));
-                        r.writeCSV(windowSize, ts, t);
-                        ts.close();
+                    if (outputToFile) {
+                        txnFileName = baseFileName + "_" + t.getName() + ".res";
+                        nextName = FileUtil.getNextFilename(txnFileName);
+                        ps = new PrintStream(new File(nextName));
                     }
+                    r.writeCSV(windowSize, ps, t);
+                    if (outputToFile)
+                        ps.close();
                 }
             }
-        } else if (LOG.isDebugEnabled()) {
-            LOG.warn("No bucket size specified");
         }
-        
+
+        XMLConfiguration xmlConfig = workConf.getXmlConfig();
+        if (isBooleanOptionSet(argsLine, "upload")) {
+
+            // Upload results
+            String uploadUrl = xmlConfig.getString("uploadUrl");
+            String uploadCode = xmlConfig.getString("uploadCode");
+            LOG.debug("uploadCode: " + uploadCode + ", uploadUrl: " + uploadUrl);
+
+            if (uploadUrl == null || uploadCode == null) {
+                LOG.warn(String.format("The upload URL/CODE cannot be null. URL: %s, CODE: %s", uploadUrl, uploadCode));
+            } else {
+                String uploadHash = argsLine.getOptionValue("uploadHash", "");
+                ResultUploader ru = new ResultUploader(uploadUrl, uploadCode, uploadHash);
+                ru.uploadResult(activeTXTypes, r, workConf, resultFiles);
+            }
+        }
+
         if (ps != null) ps.close();
-        if (rs != null) rs.close();
     }
 
     /* buggy piece of shit of Java XPath implementation made me do it 

--- a/src/com/oltpbenchmark/Database.java
+++ b/src/com/oltpbenchmark/Database.java
@@ -1,0 +1,117 @@
+package com.oltpbenchmark;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+
+import com.oltpbenchmark.types.DatabaseType;
+
+public final class Database {
+    private static final Logger LOG = Logger.getLogger(Database.class);
+
+    private final DatabaseType type;
+
+    private final String name;
+
+    private final String driver;
+
+    private final String url;
+
+    private final String username;
+
+    private final String password;
+
+    private final String version;
+
+    public Database(DatabaseType type, String name, String driver, String url, String username, String password) {
+        this(type, name, driver, url, username, password, null);
+    }
+
+    public Database(DatabaseType type, String name, String driver, String url, String username, String password,
+            String version) {
+        this.type = type;
+        this.name = name;
+        this.driver = driver;
+        this.username = username;
+        this.password = password;
+
+        // Test connection
+        Connection conn = null;
+        try {
+            conn = DriverManager.getConnection(url, username, password);;
+        } catch (SQLException ex) {
+            if (ex.getErrorCode() == 0 && ex.getSQLState().equals("01S00")) {
+                String delim = (url.contains("?")) ? ";" : "?";
+                url += delim + "serverTimezone=UTC";
+            } else {
+                throw new RuntimeException(ex);
+            }
+        }
+        this.url = url;
+
+        // Retry
+        if (conn == null) {
+            try {
+                conn = this.getConnection();
+            } catch (SQLException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        assert (conn != null);
+
+        if (version == null) {
+            // Get database version
+            try {
+                DatabaseMetaData meta = conn.getMetaData();
+                int majorVersion = meta.getDatabaseMajorVersion();
+                int minorVersion = meta.getDatabaseMinorVersion();
+                version = String.format("%s.%s", majorVersion, minorVersion);
+            } catch (SQLException ex) {
+                LOG.warn("Error extracting database version: " + ex.getMessage());
+                version = "";
+            }
+        }
+        this.version = version;
+
+        try {
+            conn.close();
+        } catch (SQLException ex) {
+        }
+    }
+
+
+    public DatabaseType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(this.url, this.username, this.password);
+    }
+}

--- a/src/com/oltpbenchmark/DistributionStatistics.java
+++ b/src/com/oltpbenchmark/DistributionStatistics.java
@@ -60,7 +60,8 @@ public class DistributionStatistics {
 	 */
 	public static DistributionStatistics computeStatistics(int[] values) {
 		if (values.length == 0) {
-			LOG.warn("cannot compute statistics for an empty list");
+            if (LOG.isDebugEnabled())
+                LOG.warn("cannot compute statistics for an empty list");
 			long[] percentiles = new long[PERCENTILES.length];
 			Arrays.fill(percentiles, -1);
 			return new DistributionStatistics(0, percentiles, -1, -1);

--- a/src/com/oltpbenchmark/Results.java
+++ b/src/com/oltpbenchmark/Results.java
@@ -77,7 +77,15 @@ public final class Results {
     }
 
     public double getRequestsPerSecond() {
-        return (double) measuredRequests / (double) nanoSeconds * 1e9;
+        return (double) getRequests() / getRuntimeSeconds();
+    }
+
+    public int getRequests() {
+        return measuredRequests;
+    }
+
+    public double getRuntimeSeconds() {
+        return (double) nanoSeconds * 1e9;
     }
 
     @Override

--- a/src/com/oltpbenchmark/Results.java
+++ b/src/com/oltpbenchmark/Results.java
@@ -85,7 +85,11 @@ public final class Results {
     }
 
     public double getRuntimeSeconds() {
-        return (double) nanoSeconds * 1e9;
+        return (double) nanoSeconds / 1e9;
+    }
+
+    public DistributionStatistics getLatencyDistribution() {
+        return this.latencyDistribution;
     }
 
     @Override
@@ -112,6 +116,10 @@ public final class Results {
     
     public void writeCSV2(PrintStream out) {
         writeCSV2(1, out, TransactionType.INVALID);
+    }
+
+    public void writeCSV2(int windowSizeSeconds, PrintStream out) {
+        writeCSV2(windowSizeSeconds, out, TransactionType.INVALID);
     }
 
     public void writeCSV2(int windowSizeSeconds, PrintStream out, TransactionType txType) {

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -14,7 +14,6 @@
  *  limitations under the License.                                            *
  ******************************************************************************/
 
-
 package com.oltpbenchmark;
 
 import java.lang.reflect.Field;
@@ -32,10 +31,40 @@ import com.oltpbenchmark.util.StringUtil;
 import com.oltpbenchmark.util.ThreadUtil;
 
 public class WorkloadConfiguration {
-    
-	private DatabaseType db_type;	
-	private String benchmarkName;
-	public String getBenchmarkName() {
+
+    private String benchmarkName;
+    private DatabaseType dbType;
+    private Database db;
+    private double scaleFactor = 1.0;
+    private double selectivity = -1.0;
+    private int terminals;
+    private int loaderThreads = ThreadUtil.availableProcessors();
+    private int numTxnTypes;
+    private TraceReader traceReader = null;
+    private int numberOfPhases = 0;
+    private TransactionTypes transTypes = null;
+    private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
+    private boolean recordAbortMessages = false;
+    private String dataDir = null;
+    private XMLConfiguration xmlConfig = null;
+    private List<Phase> works = new ArrayList<Phase>();
+    private WorkloadState workloadState;
+
+    /**
+     * Initiate a new benchmark and workload state
+     */
+    public WorkloadState initializeState(BenchmarkState benchmarkState) {
+        assert (workloadState == null);
+        workloadState = new WorkloadState(benchmarkState, works, terminals, traceReader);
+        return workloadState;
+    }
+
+    public void addWork(int time, int warmup, int rate, List<String> weights, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int active_terminals, Phase.Arrival arrival) {
+        works.add(new Phase(benchmarkName, numberOfPhases, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
+        numberOfPhases++;
+    }
+
+    public String getBenchmarkName() {
         return benchmarkName;
     }
 
@@ -43,170 +72,102 @@ public class WorkloadConfiguration {
         this.benchmarkName = benchmarkName;
     }
 
-    private String db_connection;
-	private String db_name;
-	private String db_username;
-	private String db_password;
-	private String db_driver;	
-	private double scaleFactor = 1.0;
-	private double selectivity = -1.0;
-	private int terminals;
-	private int loaderThreads = ThreadUtil.availableProcessors();
-	private int numTxnTypes;
-    private TraceReader traceReader = null;
+    public void setDBType(DatabaseType dbType) {
+        this.dbType = dbType;
+    }
+
+    public DatabaseType getDBType() {
+        return this.dbType;
+    }
+
+    public void setDB(Database db) {
+        this.db = db;
+    }
+
+    public Database getDB() {
+        return this.db;
+    }
+
+    public void setSelectivity(double selectivity) {
+        this.selectivity = selectivity;
+    }
+
+    public double getSelectivity() {
+        return this.selectivity;
+    }
+
+    public WorkloadState getWorkloadState() {
+        return workloadState;
+    }
+
     public TraceReader getTraceReader() {
         return traceReader;
     }
+
     public void setTraceReader(TraceReader traceReader) {
         this.traceReader = traceReader;
     }
-    
-	private XMLConfiguration xmlConfig = null;
 
-	private List<Phase> works = new ArrayList<Phase>();
-	private WorkloadState workloadState;
-
-	public WorkloadState getWorkloadState() {
-        return workloadState;
-    }
-	
-	/**
-	 * Initiate a new benchmark and workload state
-	 */
-    public WorkloadState initializeState(BenchmarkState benchmarkState) {
-        assert (workloadState == null);
-        workloadState = new WorkloadState(benchmarkState, works, terminals, traceReader);
-        return workloadState;
-    }
-
-    private int numberOfPhases = 0;
-	private TransactionTypes transTypes = null;
-	private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
-	private boolean recordAbortMessages = false;
-    private String dataDir = null;
-
- 
-
-    public void addWork(int time, int warmup, int rate, List<String> weights, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int active_terminals, Phase.Arrival arrival) {
-        works.add(new Phase(benchmarkName, numberOfPhases, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
-		numberOfPhases++;
-	}
-	
-	public void setDBType(DatabaseType dbType) {
-        db_type = dbType;
-    }
-	
-	public DatabaseType getDBType() {
-        return db_type;
-    }
-	
-	public void setDBConnection(String database) {
-		this.db_connection = database;
-	}
-	
-	public String getDBConnection() {
-		return db_connection;
-	}
-	
-	public void setDBName(String dbname) {
-		this.db_name = dbname;
-	}
-	
-	public void setLoaderThreads(int loaderThreads) {
-        this.loaderThreads = loaderThreads;
-    }
-	
-	/**
-	 * The number of loader threads that the framework is allowed to use.
-	 * @return
-	 */
-	public int getLoaderThreads() {
+    /**
+     * The number of loader threads that the framework is allowed to use.
+     * 
+     * @return
+     */
+    public int getLoaderThreads() {
         return this.loaderThreads;
     }
-	
-	public int getNumTxnTypes() {
-		return numTxnTypes;
-	}
-	
-	public void setNumTxnTypes(int numTxnTypes) {
-		this.numTxnTypes = numTxnTypes;
-	}
-	
-	public String getDBName() {
-		return db_name;
-	}
 
-	public void setDBUsername(String username) {
-		this.db_username = username;
-	}
-	
-	public String getDBUsername() {
-		return db_username;
-	}
-
-	public void setDBPassword(String password) {
-		this.db_password = password;
-	}
-	
-	public String getDBPassword() {
-		return this.db_password;
-	}
-
-	public void setSelectivity(double selectivity) {
-        this.selectivity = selectivity;
+    public void setLoaderThreads(int loaderThreads) {
+        this.loaderThreads = loaderThreads;
     }
-	
-	public double getSelectivity() {
-	    return this.selectivity;
-	}
 
-	public void setDBDriver(String driver) {
-		this.db_driver = driver;
-	}
-	
-	public String getDBDriver() {
-		return this.db_driver;
-	}
-	
-	public void setRecordAbortMessages(boolean recordAbortMessages) {
+    public int getNumTxnTypes() {
+        return numTxnTypes;
+    }
+
+    public void setNumTxnTypes(int numTxnTypes) {
+        this.numTxnTypes = numTxnTypes;
+    }
+
+    public void setRecordAbortMessages(boolean recordAbortMessages) {
         this.recordAbortMessages = recordAbortMessages;
     }
-	
-	/**
-	 * Whether each worker should record the transaction's UserAbort messages
-	 * This primarily useful for debugging a benchmark
-	 */
-	public boolean getRecordAbortMessages() {
+
+    /**
+     * Whether each worker should record the transaction's UserAbort messages
+     * This primarily useful for debugging a benchmark
+     */
+    public boolean getRecordAbortMessages() {
         return (this.recordAbortMessages);
     }
-	
-	/**
-	 * Set the scale factor for the database
-	 * A value of 1 means the default size.
-	 * A value greater than 1 means the database is larger
-	 * A value less than 1 means the database is smaller 
-	 * @param scaleFactor
-	 */
-	public void setScaleFactor(double scaleFactor) {
+
+    /**
+     * Set the scale factor for the database
+     * A value of 1 means the default size.
+     * A value greater than 1 means the database is larger
+     * A value less than 1 means the database is smaller 
+     * @param scaleFactor
+     */
+    public void setScaleFactor(double scaleFactor) {
         this.scaleFactor = scaleFactor;
     }
-	/**
-	 * Return the scale factor of the database size
-	 * @return
-	 */
-	public double getScaleFactor() {
+    /**
+     * Return the scale factor of the database size
+     * @return
+     */
+    public double getScaleFactor() {
         return this.scaleFactor;
     }
 
-	/**
-	 * Return the number of phases specified in the config file
-	 * @return
-	 */
-	public int getNumberOfPhases() {
-		return this.numberOfPhases;
-	}
+    /**
+     * Return the number of phases specified in the config file
+     * @return
+     */
+    public int getNumberOfPhases() {
+        return this.numberOfPhases;
+    }
 
-	/**
+    /**
      * Set the directory in which we can find the data files (for example, CSV
      * files) for loading the database.
      */ 
@@ -223,47 +184,47 @@ public class WorkloadConfiguration {
     }
 
     /**
-	 * A utility method that init the phaseIterator and dialectMap
-	 */
-	public void init() {
-	    try {
-	        Class.forName(this.db_driver);
-	    } catch (ClassNotFoundException ex) {
-	        throw new RuntimeException("Failed to initialize JDBC driver '" + this.db_driver + "'", ex);
-	    }
-	}
+     * A utility method that init the phaseIterator and dialectMap
+     */
+    public void init() {
+        try {
+            Class.forName(this.db.getDriver());
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException("Failed to initialize JDBC driver '" + this.db.getDriver() + "'", ex);
+        }
+    }
 
-	public void setTerminals(int terminals) {
-		this.terminals = terminals;
-	}
+    public void setTerminals(int terminals) {
+        this.terminals = terminals;
+    }
 
-	public int getTerminals() {
-		return terminals;
-	}
-	
-	public TransactionTypes getTransTypes() {
-		return transTypes;
-	}
+    public int getTerminals() {
+        return terminals;
+    }
 
-	public void setTransTypes(TransactionTypes transTypes) {
-		this.transTypes = transTypes;
-	}
+    public TransactionTypes getTransTypes() {
+        return transTypes;
+    }
 
-	public List<Phase> getAllPhases() {
-		return works;
-	}
+    public void setTransTypes(TransactionTypes transTypes) {
+        this.transTypes = transTypes;
+    }
 
-	public void setXmlConfig(XMLConfiguration xmlConfig) {
-		this.xmlConfig = xmlConfig;
-	}
+    public List<Phase> getAllPhases() {
+        return works;
+    }
 
-	public XMLConfiguration getXmlConfig() {
-		return xmlConfig;
-	}
+    public void setXmlConfig(XMLConfiguration xmlConfig) {
+        this.xmlConfig = xmlConfig;
+    }
 
-	public int getIsolationMode() {
-		return isolationMode;
-	}
+    public XMLConfiguration getXmlConfig() {
+        return xmlConfig;
+    }
+
+    public int getIsolationMode() {
+        return isolationMode;
+    }
 
     public String getIsolationString() {
         if(this.isolationMode== Connection.TRANSACTION_SERIALIZABLE)
@@ -278,21 +239,21 @@ public class WorkloadConfiguration {
             return "TRANSACTION_SERIALIZABLE [DEFAULT]";
     }
 
-	public void setIsolationMode(String mode) {
-		if(mode.equals("TRANSACTION_SERIALIZABLE"))
-			this.isolationMode= Connection.TRANSACTION_SERIALIZABLE;
-		else if(mode.equals("TRANSACTION_READ_COMMITTED"))
-			this.isolationMode=Connection.TRANSACTION_READ_COMMITTED;
-		else if(mode.equals("TRANSACTION_REPEATABLE_READ"))
-			this.isolationMode=Connection.TRANSACTION_REPEATABLE_READ;
-		else if(mode.equals("TRANSACTION_READ_UNCOMMITTED"))
-			this.isolationMode=Connection.TRANSACTION_READ_UNCOMMITTED;
-		else if(!mode.isEmpty())
-			System.out.println("Indefined isolation mode, set to default [TRANSACTION_SERIALIZABLE]");
-	}
-	
-	@Override
-	public String toString() {
+    public void setIsolationMode(String mode) {
+        if(mode.equals("TRANSACTION_SERIALIZABLE"))
+            this.isolationMode= Connection.TRANSACTION_SERIALIZABLE;
+        else if(mode.equals("TRANSACTION_READ_COMMITTED"))
+            this.isolationMode=Connection.TRANSACTION_READ_COMMITTED;
+        else if(mode.equals("TRANSACTION_REPEATABLE_READ"))
+            this.isolationMode=Connection.TRANSACTION_REPEATABLE_READ;
+        else if(mode.equals("TRANSACTION_READ_UNCOMMITTED"))
+            this.isolationMode=Connection.TRANSACTION_READ_UNCOMMITTED;
+        else if(!mode.isEmpty())
+            System.out.println("Indefined isolation mode, set to default [TRANSACTION_SERIALIZABLE]");
+    }
+
+    @Override
+    public String toString() {
         Class<?> confClass = this.getClass();
         Map<String, Object> m = new ListOrderedMap<String, Object>();
         for (Field f : confClass.getDeclaredFields()) {

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -111,10 +111,7 @@ public abstract class BenchmarkModule {
      * @throws SQLException
      */
     public final Connection makeConnection() throws SQLException {
-        Connection conn = DriverManager.getConnection(
-                workConf.getDBConnection(),
-                workConf.getDBUsername(),
-                workConf.getDBPassword());
+        Connection conn = workConf.getDB().getConnection();
         Catalog.setSeparator(conn);
         return (conn);
     }

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -166,7 +166,7 @@ public abstract class Loader<T extends BenchmarkModule> {
         conn.setTransactionIsolation(workConf.getIsolationMode());
         Statement st = conn.createStatement();
         for (Table catalog_tbl : catalog.getTables()) {
-            LOG.debug(String.format("Deleting data from %s.%s", workConf.getDBName(), catalog_tbl.getName()));
+            LOG.debug(String.format("Deleting data from %s.%s", workConf.getDB().getName(), catalog_tbl.getName()));
             String sql = "DELETE FROM " + catalog_tbl.getEscapedName();
             st.execute(sql);
         } // FOR

--- a/src/com/oltpbenchmark/api/collectors/MySQLCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/MySQLCollector.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 
+import com.oltpbenchmark.Database;
+
 public class MySQLCollector extends DBCollector {
 
     private static final Logger LOG = Logger.getLogger(MySQLCollector.class);
@@ -29,8 +31,8 @@ public class MySQLCollector extends DBCollector {
 
     private static final String METRICS_SQL = "SHOW GLOBAL STATUS";
 
-    public MySQLCollector(String dbUrl, String dbUsername, String dbPassword) {
-        super(dbUrl, dbUsername, dbPassword);
+    public MySQLCollector(Database database) {
+        super(database);
     }
 
     @Override

--- a/src/com/oltpbenchmark/api/collectors/NoopCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/NoopCollector.java
@@ -1,9 +1,11 @@
 package com.oltpbenchmark.api.collectors;
 
+import com.oltpbenchmark.Database;
+
 public class NoopCollector extends DBCollector {
 
-    public NoopCollector(String dbUrl, String dbUsername, String dbPassword) {
-        super(dbUrl, dbUsername, dbPassword);
+    public NoopCollector(Database database) {
+        super(database);
     }
 
     @Override

--- a/src/com/oltpbenchmark/api/collectors/PostgresCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/PostgresCollector.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 
+import com.oltpbenchmark.Database;
+
 public class PostgresCollector extends DBCollector {
 
     private static final Logger LOG = Logger.getLogger(PostgresCollector.class);
@@ -43,8 +45,8 @@ public class PostgresCollector extends DBCollector {
             "pg_statio_user_indexes"
     };
 
-    public PostgresCollector(String dbUrl, String dbUsername, String dbPassword) {
-        super(dbUrl, dbUsername, dbPassword);
+    public PostgresCollector(Database database) {
+        super(database);
     }
 
     @Override
@@ -63,7 +65,7 @@ public class PostgresCollector extends DBCollector {
         Connection conn = null;
         Map<String, List<Map<String, String>>> metrics = null;
         try {
-            conn = this.makeConnection();
+            conn = this.database.getConnection();
             metrics = new HashMap<String, List<Map<String, String>>>();
             for (String viewName : METRICS_VIEWS) {
                 try {

--- a/tests/com/oltpbenchmark/api/AbstractTestCase.java
+++ b/tests/com/oltpbenchmark/api/AbstractTestCase.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 
 import junit.framework.TestCase;
 
+import com.oltpbenchmark.Database;
 import com.oltpbenchmark.WorkloadConfiguration;
 import com.oltpbenchmark.catalog.Catalog;
 import com.oltpbenchmark.types.DatabaseType;
@@ -104,7 +105,7 @@ public abstract class AbstractTestCase<T extends BenchmarkModule> extends TestCa
         this.dbName = String.format("%s-%d.db", clazz.getSimpleName(), new Random().nextInt());
         this.workConf.setTransTypes(txnTypes);
         this.workConf.setDBType(DB_TYPE);
-        this.workConf.setDBConnection(DB_CONNECTION + this.dbName);
+        this.workConf.setDB(new Database(DB_TYPE, this.dbName, null, DB_CONNECTION + this.dbName, null, null));
         this.workConf.setScaleFactor(DB_SCALE_FACTOR);
         
         this.benchmark = (T) ClassUtil.newInstance(clazz,


### PR DESCRIPTION
Changes:

- Refactored code for writing output files

- Command-line options:
  - Added command-line flags for individual output files to provide full control over output (no files are output by default)
  - Added a few additional command-line option aliases for common output selections (e.g., output-minimal is an alias for outputting the performance summary and timeseries data)
  - Moved old/incorrect hard-coded command-line defaults into constants

- Print an execution summary after running the benchmark since we no longer output some results by default

- Updated mysql/postgres lib versions (the current mysql lib does not work with version 8.0)

- Created a new Database class to store basic info like the database name/type and connection info. It also provides a getConnection() method that handles driver/URL issues and options. For example, it sets the 'serverTimezone=UTC' option when the timezone is not properly configured in the database which is required by the new mysql-connector lib.