### PR TITLE
Chbenchmark fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ env:
   - TEST=smallbank
   - TEST=twitter
   - TEST=resourcestresser
+  - TEST=chbenchmark
 
 # Missing loader com.oltpbenchmark.benchmarks.resourcestresser.ResourceStresserBenchmark.makeLoaderImpl(ResourceStresserBenchmark.java:58)
 # -> org.apache.commons.lang.NotImplementedException: Code is not implemented
@@ -139,6 +140,13 @@ before_script:
 
 script:
   - SCALEFACTOR=0.5
+  - if [ $TEST == chbenchmark ]; then
+      BENCH=${TEST},tpcc
+      TERMINALS=1  # One terminal per workload
+    else
+      BENCH=${TEST}
+      TERMINALS=3
+    fi
   - ant bootstrap
   - ant resolve
   - if [ $TEST == junit ]; then
@@ -153,11 +161,11 @@ script:
            -e '/<username>/c\<username>travis</username>'
            -e '/<password>/c\<password>travis</password>'
            -e "/<scalefactor>/c\\<scalefactor>${SCALEFACTOR}</scalefactor>"
-           -e '/<terminals>/c\<terminals>3</terminals>'
+           -e '/<terminals>/c\<terminals>${TERMINALS}</terminals>'
            -e '/<time>/c\<time>60</time>'
            -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'
            "${config}";
-      ./oltpbenchmark --bench "${TEST}" --config "${config}" --create true --load true --execute true ;
+      ./oltpbenchmark --bench "${BENCH}" --config "${config}" --create true --load true --execute true ;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,6 @@ env:
   - TEST=smallbank
   - TEST=twitter
   - TEST=resourcestresser
-  - TEST=chbenchmark
 
 # Missing loader com.oltpbenchmark.benchmarks.resourcestresser.ResourceStresserBenchmark.makeLoaderImpl(ResourceStresserBenchmark.java:58)
 # -> org.apache.commons.lang.NotImplementedException: Code is not implemented
@@ -140,13 +139,6 @@ before_script:
 
 script:
   - SCALEFACTOR=0.5
-  - if [ $TEST == chbenchmark ]; then
-      BENCH=${TEST},tpcc
-      TERMINALS=1  # One terminal per workload
-    else
-      BENCH=${TEST}
-      TERMINALS=3
-    fi
   - ant bootstrap
   - ant resolve
   - if [ $TEST == junit ]; then
@@ -161,11 +153,11 @@ script:
            -e '/<username>/c\<username>travis</username>'
            -e '/<password>/c\<password>travis</password>'
            -e "/<scalefactor>/c\\<scalefactor>${SCALEFACTOR}</scalefactor>"
-           -e '/<terminals>/c\<terminals>${TERMINALS}</terminals>'
+           -e '/<terminals>/c\<terminals>3</terminals>'
            -e '/<time>/c\<time>60</time>'
            -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'
            "${config}";
-      ./oltpbenchmark --bench "${BENCH}" --config "${config}" --create true --load true --execute true ;
+      ./oltpbenchmark --bench "${TEST}" --config "${config}" --create true --load true --execute true ;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ env:
   - TEST=smallbank
   - TEST=twitter
   - TEST=resourcestresser
+  - TEST=chbenchmark
 
 # Missing loader com.oltpbenchmark.benchmarks.resourcestresser.ResourceStresserBenchmark.makeLoaderImpl(ResourceStresserBenchmark.java:58)
 # -> org.apache.commons.lang.NotImplementedException: Code is not implemented

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,8 @@ install:
       DB=postgres ;
     fi
   - if [ $DB == mysql ]; then mysql -e "SELECT VERSION()";
+      echo -e "[mysqld]\nlower_case_table_names=1" | sudo tee -a /etc/mysql/my.cnf ;
+      sudo service mysql restart ;
       mysql -e "CREATE DATABASE IF NOT EXISTS ${TEST}" ;
       mysql -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY 'travis'; GRANT ALL ON *.* TO 'travis'@'localhost'";
     elif [ $DB == postgres ]; then psql -c "SELECT VERSION()" -U travis;
@@ -139,6 +141,13 @@ before_script:
 
 script:
   - SCALEFACTOR=0.5
+  - TIME=60
+  - TERMINALS=3
+  - if [ $TEST == chbenchmark ]; then
+      BENCH=${TEST},tpcc ;
+    else
+      BENCH=${TEST} ;
+    fi
   - ant bootstrap
   - ant resolve
   - if [ $TEST == junit ]; then
@@ -150,14 +159,14 @@ script:
            -e "/<dbtype>/c\<dbtype>${TYPE}</dbtype>"
            -e "/<driver>/c\<driver>${DRIVER}</driver>"
            -e "/<DBUrl>/c\<DBUrl>${URLBASE}/${TEST}</DBUrl>"
-           -e '/<username>/c\<username>travis</username>'
-           -e '/<password>/c\<password>travis</password>'
+           -e "/<username>/c\<username>travis</username>"
+           -e "/<password>/c\<password>travis</password>"
            -e "/<scalefactor>/c\\<scalefactor>${SCALEFACTOR}</scalefactor>"
-           -e '/<terminals>/c\<terminals>3</terminals>'
-           -e '/<time>/c\<time>60</time>'
-           -e '/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>'
+           -e "/<terminals>/c\<terminals>${TERMINALS}</terminals>"
+           -e "/<time>/c\<time>${TIME}</time>"
+           -e "/<isolation>/c\<isolation>TRANSACTION_READ_COMMITTED</isolation>"
            "${config}";
-      ./oltpbenchmark --bench "${TEST}" --config "${config}" --create true --load true --execute true ;
+      ./oltpbenchmark --bench "${BENCH}" --config "${config}" --create true --load true --execute true ;
     fi
 
 

--- a/config/sample_chbenchmark_config.xml
+++ b/config/sample_chbenchmark_config.xml
@@ -1,103 +1,162 @@
 <?xml version="1.0"?>
 <parameters>
-	
-    <!-- Connection details -->
+
+	<!-- Connection details -->
     <dbtype>mysql</dbtype>
     <driver>com.mysql.jdbc.Driver</driver>
-    <DBUrl>jdbc:mysql://localhost:3306/tpcc</DBUrl>
+    <DBUrl>jdbc:mysql://localhost:3306/chbenchmark</DBUrl>
     <username>root</username>
     <password></password>
     <isolation>TRANSACTION_SERIALIZABLE</isolation>
     <uploadCode></uploadCode>
     <uploadUrl></uploadUrl>
-    
-    <!-- Scale factor is the number of warehouses in TPCC -->
-    <scalefactor>2</scalefactor>
-    
-    <!-- The workload -->
-    <terminals>2</terminals>
-    <works>
-        <work>
-          <time>10</time>
-          <rate>10000</rate>
-          <weights>10, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5</weights>
-        </work>
+
+	<!-- Scale factor is the number of warehouses in TPCC -->
+	<scalefactor>2</scalefactor>
+
+	<!-- The workload -->
+	<!-- Number of terminal per workload -->
+	<terminals>2</terminals>
+
+	<!-- Note: Workload-specific options are marked with @bench=[workload_name] -->
+
+	<!-- Workload-specific number of terminals -->
+	<!-- <terminals bench="chbenchmark">2</terminals> -->
+	<!-- <terminals bench="tpcc">5</terminals> -->
+
+	<works>
+ 
+	    <!-- A Basic WorkPhase for Mixed Workloads -->
+		<work>
+			<time>60</time>
+
+			<!-- Note: The rate can also be set to UNLIMITED or DISABLED -->
+			<rate>10000</rate>
+
+            <!-- Serial execution of the chbenchmark queries -->
+            <!-- Note: Weights are interpreted differently when serial is enabled: -->
+            <!--   Queries with positive weights are executed -->
+            <!--   Queries with negative weights are skipped -->
+            <serial bench="chbenchmark">true</serial>
+
+            <!-- Non-serial execution of the tpcc transactions -->
+            <serial bench="tpcc">false</serial>
+
+			<!-- Must specify transaction weights for each workload -->
+			<weights bench="chbenchmark">5, 5, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4</weights>
+			<weights bench="tpcc">45,43,4,4,4</weights>
+		</work>
+
+	    <!-- Extra features showcase -->
+        <!-- <work> -->
+			<!-- <time>10</time> -->
+
+            <!-- Workload-specific rates -->
+			<!-- <rate bench="chbenchmark">unlimited</rate> -->
+			<!-- <rate bench="tpcc">100</rate> -->
+
+            <!-- Number of active terminals per work -->
+			<!-- NOTE: TPCC workers won't be distributed evenly between -->
+            <!-- warehouses if some workers are inactive -->
+			<!-- <active_terminals>2</active_terminals> -->
+			<!-- <active_terminals bench="chbenchmark">1</active_terminals> -->
+
+			<!-- Specifies transaction weight for each workload. -->
+			<!--<weights bench="tpcc">45,43,4,4,4</weights> -->
+			<!-- <weights bench="chbenchmark">5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 8, 5, 7, 5, 5, 5, 5</weights> -->
+		<!-- </work> -->
+
 	</works>
-	
-	<!-- TPCC specific -->  
-   	<transactiontypes>
-    	<transactiontype>
-    		<name>Q1</name>
-    	</transactiontype>
-    	<!-- Doesn't work with MysQL
-    	<transactiontype>
-    		<name>Q2</name>
-    	</transactiontype>
-    	-->
-    	<transactiontype>
-    		<name>Q3</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q4</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q5</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q6</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q7</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q8</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q9</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q10</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q11</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q12</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q13</name>
-    	</transactiontype>    	
-    	<transactiontype>
-    		<name>Q14</name>
-    	</transactiontype>      
-    	<transactiontype>
-    	<!-- Needs optimization -->
-    		<name>Q15</name>
-    	</transactiontype>   
-    	<transactiontype>
-    		<name>Q16</name>
-    	</transactiontype>
-    	<!-- Doesn't work with MySQL
-    	<transactiontype>
-    		<name>Q17</name>
-    	</transactiontype>   
-    	-->
-    	<transactiontype>
-    		<name>Q18</name>
-    	</transactiontype>   
-    	<transactiontype>
-    		<name>Q19</name>
-    	</transactiontype>
-    	<!-- Doesn't work with MySQL
-    	<transactiontype>
-    		<name>Q20</name>
-    	</transactiontype>
-    	-->   
-    	<transactiontype>
-    		<name>Q21</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Q22</name>
-    	</transactiontype>
-   	</transactiontypes>	
+
+	<!-- Must list all transactions -->
+
+	<!-- CH specific -->
+	<transactiontypes bench="chbenchmark">
+		<transactiontype>
+			<name>Q1</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q2</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q3</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q4</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q5</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q6</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q7</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q8</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q9</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q10</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q11</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q12</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q13</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q14</name>
+		</transactiontype>
+		<transactiontype>
+			<!-- Needs optimization -->
+			<name>Q15</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q16</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q17</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q18</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q19</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q20</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q21</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Q22</name>
+		</transactiontype>
+	</transactiontypes>
+
+	<!-- TPCC specific -->
+	<transactiontypes bench="tpcc">
+		<transactiontype>
+			<name>NewOrder</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Payment</name>
+		</transactiontype>
+		<transactiontype>
+			<name>OrderStatus</name>
+		</transactiontype>
+		<transactiontype>
+			<name>Delivery</name>
+		</transactiontype>
+		<transactiontype>
+			<name>StockLevel</name>
+		</transactiontype>
+	</transactiontypes>
 </parameters>

--- a/src/com/oltpbenchmark/Phase.java
+++ b/src/com/oltpbenchmark/Phase.java
@@ -126,8 +126,10 @@ public class Phase {
     }
 
     public void resetSerial() {
-        this.nextSerials.clear();
-        this.nextSerials.addAll(this.startSerials);
+        if (this.serial) {
+            this.nextSerials.clear();
+            this.nextSerials.addAll(this.startSerials);
+        }
     }
 
     public int getActiveTerminals() {

--- a/src/com/oltpbenchmark/Phase.java
+++ b/src/com/oltpbenchmark/Phase.java
@@ -21,9 +21,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.log4j.Logger;
+
 import com.oltpbenchmark.util.StringUtil;
 
 public class Phase {
+    private static final Logger LOG = Logger.getLogger(Phase.class);
+
     public enum Arrival {
         REGULAR,POISSON,
     }
@@ -35,19 +39,18 @@ public class Phase {
     public final int warmupTime;
     public final int rate;
     public final Arrival arrival;
-
-
     private final boolean rateLimited;
     private final boolean disabled;
     private final boolean serial;
+    private final List<Integer> nextSerials;
+    private final List<Integer> startSerials;
     private final boolean timed;
     private final List<Double> weights;
     private final int num_weights;
     private int activeTerminals;
-    private int nextSerial;
-    
 
-    Phase(String benchmarkName, int id, int t, int wt, int r, List<String> o, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int activeTerminals, Arrival a) {
+    Phase(String benchmarkName, int id, int t, int wt, int r, List<String> o, boolean rateLimited, boolean disabled,
+            boolean serial, boolean timed, int activeTerminals, Arrival a) {
         ArrayList<Double> w = new ArrayList<Double>();
         for (String s : o)
             w.add(Double.parseDouble(s));
@@ -63,11 +66,41 @@ public class Phase {
         this.disabled = disabled;
         this.serial = serial;
         this.timed = timed;
-        this.nextSerial = 1;
         this.activeTerminals = activeTerminals;
         this.arrival=a;
+
+        if (this.serial) {
+            List<Integer> starts = new ArrayList<Integer>(this.activeTerminals);
+
+            if (this.activeTerminals > 1 && this.isThroughputRun()) {
+                // If it's a throughput run, then workers will execute queries serially
+                // in a loop until the timer expires. We assign workers different starting
+                // queries instead of starting them all on query 1.
+
+                // Only consider queries with positive weights
+                List<Integer> valid = new ArrayList<Integer>();
+                for (int i = 0; i < this.num_weights; ++i) {
+                    if (this.weights.get(i) > 0)
+                        valid.add(i + 1);
+                }
+                int spread = Math.max((int) ((float) valid.size() / this.activeTerminals), 1);
+                for (int i = 0; i < this.activeTerminals; ++i)
+                    starts.add(((i * spread) % this.num_weights) + 1);
+
+            } else {
+                for (int i = 0; i < this.activeTerminals; ++i)
+                    starts.add(1);
+            }
+            this.startSerials = Collections.unmodifiableList(starts);
+            this.nextSerials = new ArrayList<Integer>(this.startSerials);
+            LOG.debug(String.format("Reset serial exec starting queries for %d terminals to: %s", this.activeTerminals,
+                    StringUtil.join(", ", this.startSerials)));
+        } else {
+            this.startSerials = null;
+            this.nextSerials = null;
+        }
     }
-    
+
     public boolean isRateLimited() {
         return rateLimited;
     }
@@ -93,7 +126,8 @@ public class Phase {
     }
 
     public void resetSerial() {
-        this.nextSerial = 1;
+        this.nextSerials.clear();
+        this.nextSerials.addAll(this.startSerials);
     }
 
     public int getActiveTerminals() {
@@ -126,21 +160,23 @@ public class Phase {
      * @return
      */
     public int chooseTransaction() {
-        return chooseTransaction(false);
+        return chooseTransaction(false, 0);
     }
-    public int chooseTransaction(boolean isColdQuery) {
+
+    public int chooseTransaction(boolean isColdQuery, int terminalId) {
         if (isDisabled())
             return -1;
 
         if (isSerial()) {
             int ret;
             synchronized(this) {
-                ret = this.nextSerial;
+                int next = this.nextSerials.get(terminalId);
+                ret = next;
 
                 // Serial runs should not execute queries with non-positive
                 // weights.
-                while (ret <= this.num_weights && weights.get(ret - 1).doubleValue() <= 0.0)
-                    ret = ++this.nextSerial;
+                while (ret < this.num_weights && weights.get(ret - 1).doubleValue() <= 0.0)
+                    ret = ++next;
 
                 // If it's a cold execution, then we don't want to advance yet,
                 // since the hot run needs to execute the same query.
@@ -151,12 +187,14 @@ public class Phase {
                     // so that we end up in the range [1,num_weights]
                     if (isTimed()) {
                         assert this.isThroughputRun();
-                        this.nextSerial %= this.num_weights;
+                        next %= this.num_weights;
                     }
 
-                    ++this.nextSerial;
+                    ++next;
                 }
+                this.nextSerials.set(terminalId, next);
             }
+            LOG.debug(String.format("Worker %d (serial): executing txn #%d next", terminalId, ret));
             return ret;
         }
         else {

--- a/src/com/oltpbenchmark/WorkloadState.java
+++ b/src/com/oltpbenchmark/WorkloadState.java
@@ -119,7 +119,7 @@ public class WorkloadState {
    }
    
    /** Called by ThreadPoolThreads when waiting for work. */
-    public SubmittedProcedure fetchWork() {
+    public SubmittedProcedure fetchWork(int workerId) {
         synchronized(this) {
             if (currentPhase != null && currentPhase.isSerial()) {
                 ++workersWaiting;
@@ -136,7 +136,7 @@ public class WorkloadState {
                     return null;
 
                 ++workersWorking;
-                return new SubmittedProcedure(currentPhase.chooseTransaction(getGlobalState() == State.COLD_QUERY));
+                return new SubmittedProcedure(currentPhase.chooseTransaction(getGlobalState() == State.COLD_QUERY, workerId));
             }
         }
 
@@ -147,7 +147,7 @@ public class WorkloadState {
             synchronized(this) {
                 ++workersWorking;
             }
-            return new SubmittedProcedure(currentPhase.chooseTransaction(getGlobalState() == State.COLD_QUERY));
+            return new SubmittedProcedure(currentPhase.chooseTransaction(getGlobalState() == State.COLD_QUERY, workerId));
         }
 
         synchronized(this) {

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -264,7 +264,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
             // Grab some work and update the state, in case it changed while we
             // waited.
-            pieceOfWork = wrkldState.fetchWork();
+            pieceOfWork = wrkldState.fetchWork(this.id);
             preState = wrkldState.getGlobalState();
 
             phase = this.wrkldState.getCurrentPhase();


### PR DESCRIPTION
- Added support for multiple workers in serial execution mode which was previously limited to 1 (but still warn the user since this is a less common setting).

- When running in serial mode with multiple workers, each worker starts with a different query instead of all starting at Q1.

- Fixed the sample config and added chbenchmark to the travis config
