### PR TITLE
fix NULL pointer return

### DIFF
--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -516,7 +516,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                             break;
                         case RETRY_DIFFERENT:
                             this.txnRetry.put(next);
-                            return null;
+                            break;
                         case USER_ABORTED:
                             this.txnAbort.put(next);
                             break;


### PR DESCRIPTION
doWork () does not seem to return NULL. 

It crashes the auctionMark to run properly, and it seems working now.

It is a very simple change, but I would appreciate it if someone who knows the OLTPBenchmark code structure can verify my change.
