### PR TITLE
Fix "ant resolve", add ivysettings.xml to use HTTPS versions of Maven and Apache repos.

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,0 +1,9 @@
+<ivysettings>
+    <settings defaultResolver="chain"/>
+    <resolvers>
+        <chain name="chain">
+            <ibiblio name="maven" m2compatible="true" root="https://repo1.maven.org/maven2/"/>
+            <ibiblio name="apache" m2compatible="true" root="https://repo.maven.apache.org/maven2/"/>
+        </chain>
+    </resolvers>
+</ivysettings>


### PR DESCRIPTION
On 2020-01-15, the Maven repositories were updated to reject all HTTP requests [0].
This breaks `ant resolve`.
This makes Apache Ivy use HTTPS instead.

[0] https://blog.sonatype.com/central-repository-moving-to-https