### PR TITLE
Update PostgreSQL dependency from 9.4.1209 to 42.2.9.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -21,7 +21,7 @@
 	<dependencies>
       <!-- JDBC Drivers -->
 		<dependency org="org.xerial" name="sqlite-jdbc" rev="3.6.20" force="true" conf="test->compile(*),runtime(*),master(*)"/>
-		<dependency org="org.postgresql" name="postgresql" rev="9.4.1209" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+		<dependency org="org.postgresql" name="postgresql" rev="42.2.9" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="mysql" name="mysql-connector-java" rev="5.1.47"/>
 		<dependency org="org.hsqldb" name="hsqldb" rev="2.4.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 


### PR DESCRIPTION
This enables the preferQueryMode simple option as a JDBC connection string or as a DriverManager Property setting; this is useful for interfacing with systems without support for prepared statements.