### PR TITLE
Add support for generating auctionmark databases with a larger scalefactor

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/auctionmark/AuctionMarkLoader.java
@@ -604,7 +604,7 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         
         private final LinkedBlockingDeque<T> queue = new LinkedBlockingDeque<T>();
         private T current;
-        private short currentCounter;
+        private int currentCounter;
         private boolean stop = false;
         private final String sourceTableName;
 
@@ -613,8 +613,8 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
             this.sourceTableName = sourceTableName;
         }
         
-        protected abstract short getElementCounter(T t);
-        protected abstract int populateRow(T t, Object[] row, short remaining);
+        protected abstract int getElementCounter(T t);
+        protected abstract int populateRow(T t, Object[] row, int remaining);
         
         public void stopWhenEmpty() {
             if (LOG.isDebugEnabled())
@@ -949,11 +949,11 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                                                     AuctionMarkConstants.USER_MAX_ATTRIBUTES, 1.001);
         }
         @Override
-        protected short getElementCounter(UserId user_id) {
-            return (short)(randomNumUserAttributes.nextInt());
+        protected int getElementCounter(UserId user_id) {
+            return (int)(randomNumUserAttributes.nextInt());
         }
         @Override
-        protected int populateRow(UserId user_id, Object[] row, short remaining) {
+        protected int populateRow(UserId user_id, Object[] row, int remaining) {
             int col = 0;
             
             // UA_ID
@@ -991,8 +991,8 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
         
         @Override
-        protected short getElementCounter(UserId user_id) {
-            return (short)(user_id.getItemCount());
+        protected int getElementCounter(UserId user_id) {
+            return (int)(user_id.getItemCount());
         }
 
         @Override
@@ -1004,7 +1004,7 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
             } // FOR
         }
         @Override
-        protected int populateRow(UserId seller_id, Object[] row, short remaining) {
+        protected int populateRow(UserId seller_id, Object[] row, int remaining) {
             int col = 0;
             
             ItemId itemId = new ItemId(seller_id, remaining);
@@ -1030,8 +1030,8 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
             assert(p != null);
 
             // Calculate the number of bids and watches for this item
-            short numBids = (short)p.first.nextInt();
-            short numWatches = (short)p.second.nextInt();
+            int numBids = p.first.nextInt();
+            int numWatches = p.second.nextInt();
             
             // Create the ItemInfo object that we will use to cache the local data 
             // for this item. This will get garbage collected once all the derivative
@@ -1044,7 +1044,7 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
             itemInfo.numImages = (short) profile.randomNumImages.nextInt();
             itemInfo.numAttributes = (short) profile.randomNumAttributes.nextInt();
             itemInfo.numBids = numBids;
-            itemInfo.numWatches = numWatches;
+            itemInfo.numWatches = (short) numWatches;
             
             // The auction for this item has already closed
             if (itemInfo.endDate.getTime() <= profile.getLoaderStartTime().getTime()) {
@@ -1139,11 +1139,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return itemInfo.numImages;
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
 
             // II_ID
@@ -1169,11 +1170,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_GLOBAL_ATTRIBUTE_VALUE);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return itemInfo.numAttributes;
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             GlobalAttributeValueId gav_id = profile.getRandomGlobalAttributeValue();
             assert(gav_id != null);
@@ -1203,11 +1205,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return (itemInfo.purchaseDate != null ? itemInfo.numComments : 0);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
 
             // IC_ID
@@ -1254,11 +1257,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return ((short)itemInfo.numBids);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return ((int)itemInfo.numBids);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             assert(itemInfo.numBids > 0);
             
@@ -1356,11 +1360,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM_BID);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short)(itemInfo.getBidCount() > 0 ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return (int)(itemInfo.getBidCount() > 0 ? 1 : 0);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
             assert(bid != null) : "No bids?\n" + itemInfo;
@@ -1394,11 +1399,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM_BID);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short)(itemInfo.getBidCount() > 0 && itemInfo.purchaseDate != null ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return (int)(itemInfo.getBidCount() > 0 && itemInfo.purchaseDate != null ? 1 : 0);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
             assert(bid != null) : itemInfo;
@@ -1437,11 +1443,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
         }
 
         @Override
-        protected short getElementCounter(LoaderItemInfo.Bid bid) {
-            return (short)((bid.buyer_feedback ? 1 : 0) + (bid.seller_feedback ? 1 : 0));
+        protected int getElementCounter(LoaderItemInfo.Bid bid) {
+            return (int)((bid.buyer_feedback ? 1 : 0) + (bid.seller_feedback ? 1 : 0));
         }
         @Override
-        protected int populateRow(LoaderItemInfo.Bid bid, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo.Bid bid, Object[] row,
+                int remaining) {
             int col = 0;
 
             boolean is_buyer = false;
@@ -1480,11 +1487,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM_BID);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
-            return (short)(itemInfo.getBidCount() > 0 && itemInfo.purchaseDate != null ? 1 : 0);
+        public int getElementCounter(LoaderItemInfo itemInfo) {
+            return (int)(itemInfo.getBidCount() > 0 && itemInfo.purchaseDate != null ? 1 : 0);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             LoaderItemInfo.Bid bid = itemInfo.getLastBid();
             assert(bid != null) : itemInfo;
@@ -1522,11 +1530,12 @@ public class AuctionMarkLoader extends Loader<AuctionMarkBenchmark> {
                   AuctionMarkConstants.TABLENAME_ITEM_BID);
         }
         @Override
-        public short getElementCounter(LoaderItemInfo itemInfo) {
+        public int getElementCounter(LoaderItemInfo itemInfo) {
             return (itemInfo.numWatches);
         }
         @Override
-        protected int populateRow(LoaderItemInfo itemInfo, Object[] row, short remaining) {
+        protected int populateRow(LoaderItemInfo itemInfo, Object[] row,
+                int remaining) {
             int col = 0;
             
             // Make it more likely that a user that has bid on an item is watching it

--- a/src/com/oltpbenchmark/benchmarks/auctionmark/util/ItemId.java
+++ b/src/com/oltpbenchmark/benchmarks/auctionmark/util/ItemId.java
@@ -28,7 +28,7 @@ import com.oltpbenchmark.util.CompositeId;
 public class ItemId extends CompositeId {
 
     private static final int COMPOSITE_BITS[] = {
-        40, // SELLER_ID
+        44, // SELLER_ID
         16, // ITEM_CTR
     };
     private static final long COMPOSITE_POWS[] = compositeBitsPreCompute(COMPOSITE_BITS);

--- a/src/com/oltpbenchmark/benchmarks/auctionmark/util/UserId.java
+++ b/src/com/oltpbenchmark/benchmarks/auctionmark/util/UserId.java
@@ -22,8 +22,8 @@ import com.oltpbenchmark.util.CompositeId;
 public class UserId extends CompositeId {
     
     private static final int COMPOSITE_BITS[] = {
-        16, // ITEM_COUNT
-        24, // OFFSET
+        20, // OFFSET
+        24, // ITEM_COUNT
     };
     private static final long COMPOSITE_POWS[] = compositeBitsPreCompute(COMPOSITE_BITS);
     

--- a/src/com/oltpbenchmark/util/CompositeId.java
+++ b/src/com/oltpbenchmark/util/CompositeId.java
@@ -48,12 +48,16 @@ public abstract class CompositeId implements Comparable<CompositeId>, JSONSerial
         for (int i = 0; i < values.length; i++) {
             long max_value = offset_pows[i];
 
-            assert(values[i] >= 0) :
-                String.format("%s value at position %d is %d %s",
-                              this.getClass().getSimpleName(), i, values[i], Arrays.toString(values));
-            assert(values[i] < max_value) :
-                String.format("%s value at position %d is %d. Max value is %d\n%s",
-                              this.getClass().getSimpleName(), i, values[i], max_value, this);
+            if(values[i] < 0) {
+                throw new IllegalArgumentException(String.format("%s value at position %d is %d %s",
+                              this.getClass().getSimpleName(), i,
+                              values[i], Arrays.toString(values)));
+            }
+            if(values[i] >= max_value) {
+                throw new IllegalArgumentException(String.format("%s value at position %d is %d. Max value is %d\n",
+                              this.getClass().getSimpleName(), i,
+                              values[i], max_value));
+            }
             
             id = (i == 0 ? values[i] : id | values[i]<<offset);
             offset += offset_bits[i];

--- a/tests/com/oltpbenchmark/util/TestCompositeIdRange.java
+++ b/tests/com/oltpbenchmark/util/TestCompositeIdRange.java
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *  Copyright 2020 by OLTPBenchmark Project                                   *
+ *                                                                            *
+ *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  you may not use this file except in compliance with the License.          *
+ *  You may obtain a copy of the License at                                   *
+ *                                                                            *
+ *    http://www.apache.org/licenses/LICENSE-2.0                              *
+ *                                                                            *
+ *  Unless required by applicable law or agreed to in writing, software       *
+ *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ *  See the License for the specific language governing permissions and       *
+ *  limitations under the License.                                            *
+ ******************************************************************************/
+
+
+package com.oltpbenchmark.util;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class TestCompositeIdRange {
+
+    public class PackedLong extends CompositeId {
+        protected final int COMPOSITE_BITS[] = {
+            16, // FIELD1
+            32, // FIELD2
+        };
+        protected final long COMPOSITE_POWS[] = compositeBitsPreCompute(COMPOSITE_BITS);
+
+        protected int field1;
+        protected int field2;
+
+        public PackedLong() {
+        }
+
+        public PackedLong(int field1, int field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        @Override
+        public long encode() {
+            return (this.encode(this.COMPOSITE_BITS, this.COMPOSITE_POWS));
+        }
+
+        @Override
+        public void decode(long composite_id) {
+            long values[] = super.decode(composite_id, this.COMPOSITE_BITS,this. COMPOSITE_POWS);
+            this.field1 = (int)values[0];
+            this.field2 = (int)values[1];
+        }
+
+        @Override
+        public long[] toArray() {
+            return (new long[]{ this.field1, this.field2 });
+        }
+
+        public int getField1() {
+            return this.field1;
+        } 
+
+        public int getField2() {
+            return this.field2;
+        }
+    }
+
+    @Test
+    public void testPackOK() {
+        PackedLong packedLong = new PackedLong(1, 2);
+        long encodedLong = packedLong.encode();
+        PackedLong packedLong2 = new PackedLong();
+        packedLong2.decode(encodedLong);
+        assertEquals(packedLong.getField1(), packedLong2.getField1());
+        assertEquals(packedLong.getField2(), packedLong2.getField2());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOutOfRange() {
+        // Won't fit, we have allocated only 16 bits to field 1
+        PackedLong packedLong = new PackedLong(Integer.MAX_VALUE, Integer.MAX_VALUE); 
+        long encodedLong = packedLong.encode();
+    }
+
+}


### PR DESCRIPTION
When generating an auctionmark database with a larger scale factor (e.g. 50), there are collisions in `UserId`s because there not enough bits allocated for `OFFSET`. There is some space left over in the `CompositeId`, so I've allocated a few more bits. Also, I've reordered the fields in `UserId` to match how they are packed in the compositeId. I've verified that this fix works to generate an auctionmark database with scalefactor 50.

The number of rows also exceeds the max values for `short`, so I've switched those to `int` in AuctionmarkLoader.

I propose changing the encode method on `CompositeId` to throw an `IllegalArgumentException` rather than assert. By default, asserts are not triggered, which means that we receive no warning that IDs may collide. This issue results in confusing errors that are difficult to track down for end-users. I've added code and a test to this effect.

All other tests pass with `ant junit.`