### PR TITLE
Add support for running oltpbenchmark as an external executable tool.

### DIFF
--- a/classpath.sh
+++ b/classpath.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo -ne "build"
-for i in `ls lib/*.jar`; do
+echo -ne "$OLTPBENCH_HOME./build"
+for i in `ls $OLTPBENCH_HOME./lib/*.jar`; do
     # IMPORTANT: Make sure that we do not include hsqldb v1
     if [[ $i =~ .*hsqldb-1.* ]]; then
         continue

--- a/oltpbenchmark
+++ b/oltpbenchmark
@@ -1,3 +1,3 @@
 #!/bin/bash
-java -Xmx8G -cp `./classpath.sh bin` -Dlog4j.configuration=log4j.properties com.oltpbenchmark.DBWorkload $@
-
+# OLTPBENCH_HOME should be empty or end with "/"
+java -Xmx8G -cp `$OLTPBENCH_HOME./classpath.sh bin` -Dlog4j.configuration=$OLTPBENCH_HOME./log4j.properties com.oltpbenchmark.DBWorkload $@

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -84,7 +84,8 @@ public class DBWorkload {
         CommandLineParser parser = new PosixParser();
         XMLConfiguration pluginConfig=null;
         try {
-            pluginConfig = new XMLConfiguration("config/plugin.xml");
+            // OLTPBENCH_HOME should be empty or end with "/"
+            pluginConfig = new XMLConfiguration(System.getenv("OLTPBENCH_HOME")+"config/plugin.xml");
         } catch (ConfigurationException e1) {
             LOG.info("Plugin configuration file config/plugin.xml is missing");
             e1.printStackTrace();


### PR DESCRIPTION
Currently, the command `oltpbenchmark` can only run in the home folder of the project. If user wants to run `oltpbenchmark` as an external command(which could be easily integrated into the code), they should fix several hard-coded places.

Here, I add the `OLTPBENCH_HOME` environmental variable to support this. There is no pollution or previous logic(OLTPBENCH_HOME can be empty in case of not setting it).

Usage:
`export OLTPBENCH_HOME=~/oltpbench/`