### PR TITLE
Use /bin/sh instead of /bin/bash for start scripts

### DIFF
--- a/classpath.sh
+++ b/classpath.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo -ne "build"
 for i in `ls lib/*.jar`; do

--- a/oltpbenchmark
+++ b/oltpbenchmark
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 java -Xmx8G -cp `./classpath.sh bin` -Dlog4j.configuration=log4j.properties com.oltpbenchmark.DBWorkload $@
 


### PR DESCRIPTION
Some more esoteric Unix-like variants (in my case NixOS) don't have `bash` symlinked from `/bin` (which is common, but not part of the File Hierarchy Standard) but _do_ have `/bin/sh` (which is).

This PR just changes the shebang line in each of the relevant start scripts to `/bin/sh` instead of bash, which seems to works fine.