### PR TITLE
Add Dockerfile to run OLTPBench as a container.

### DIFF
--- a/.deploy/install.sh
+++ b/.deploy/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+set -e
+set -u
+set -C
+# Add the unzip util to the container.
+apt-get update -q
+apt-get install -yq unzip
+# Move the ant distribution into the PATH
+mv .deploy/ant-v1.9.15.zip /usr/local/bin
+cd /usr/local/bin
+unzip -q ant-v1.9.15.zip
+# Remove the binary distribution, now that we have an unzipped copy.
+rm /usr/local/bin/ant-v1.9.15.zip
+# Return to the working directory.
+cd -
+PATH=$PATH:/usr/local/bin/apache-ant-1.9.15/bin
+# Install Ivy, resolve dependencies, and build OLTPBench.
+ant bootstrap
+ant resolve 2> /dev/null # There's a harmless warning message that clogs the console.
+ant build

--- a/.deploy/main.sh
+++ b/.deploy/main.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+set -u
+set -C
+# Read the file passed in through STDIN to disk for OLTPBench to reference.
+cat /dev/stdin > config/docker_workload.xml
+# Run the benchmarker using the remaining arguments.
+./oltpbenchmark -c config/docker_workload.xml "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:16-slim-buster
+COPY . /usr/src/oltpbench
+WORKDIR /usr/src/oltpbench
+RUN .deploy/install.sh
+ENV PATH="/usr/local/bin/apache-ant-1.9.15/bin:$PATH"
+ENTRYPOINT [".deploy/main.sh"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ benchmark, leveraging all the system features (logging, controlled speed, contro
 
 See the [on-line documentation](https://github.com/oltpbenchmark/oltpbench/wiki) on how to use OLTP-Bench.
 
+## Docker
+
+A Dockerfile has been provided for running OLTPBench interactively without having to build the dependencies. To build the Docker image, run:
+
+```bash
+docker build -t oltpbench .
+```
+
+This command builds the OLTPBench image with the tag `oltpbench`. 
+
+The Docker container will read the configuration file from STDIN. All other parameters must still be passed in through the container. For example, to use the [example](https://github.com/oltpbenchmark/oltpbench/wiki) from the docs, 
+
+```bash
+cat ./config/sample_tpcc_config.xml | docker run -i oltpbench -b tpcc --create=true --load=true --execute=true -s 5 -o outputfile
+```
+
+This will run the image created above using the tag we provided, passing in the configuration file `sample_tpcc_config.xml` found in the `config` directory.
+
 ## Publications
 
 If you are using this framework for your papers or for your work, please cite the paper:


### PR DESCRIPTION
This commit allows users to run OLTPBench without installing
Java/Ant/Ivy. It provides a Dockerfile to build and run Docker images
with OLTPBench installed.