### PR TITLE
Load TPC-C ITEM with multiple threads.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
@@ -73,17 +73,26 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
     @Override
     public List<LoaderThread> createLoaderThreads() throws SQLException {
         List<LoaderThread> threads = new ArrayList<LoaderThread>();
-        final CountDownLatch itemLatch = new CountDownLatch(1);
-        
+        int numLoaders = this.workConf.getLoaderThreads();
+        final CountDownLatch itemLatch = new CountDownLatch(numLoaders);
+
         // ITEM
-        // This will be invoked first and executed in a single thread. 
-        threads.add(new LoaderThread() {
-            @Override
-            public void load(Connection conn) throws SQLException {
-                loadItems(conn, TPCCConfig.configItemCount);
-                itemLatch.countDown();                
-            }
-        });
+        // The ITEM table will be fully loaded before any other table.
+        // Because the ITEM table is large (100k items per the TPC-C spec),
+        // we divide the ITEM table across the maximum number of loader threads.
+        for (int i = 1; i <= TPCCConfig.configItemCount;) {
+            int numItemsPerLoader = TPCCConfig.configItemCount / numLoaders;
+            int itemStartInclusive = i;
+            int itemEndInclusive = Math.min(TPCCConfig.configItemCount, itemStartInclusive + numItemsPerLoader - 1);
+            threads.add(new LoaderThread() {
+                @Override
+                public void load(Connection conn) throws SQLException {
+                    loadItems(conn, itemStartInclusive, itemEndInclusive);
+                    itemLatch.countDown();
+                }
+            });
+            i = itemEndInclusive + 1;
+        }
         
         // WAREHOUSES
         // We use a separate thread per warehouse. Each thread will load 
@@ -150,7 +159,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
         }
     }
 
-    protected int loadItems(Connection conn, int itemKount) {
+    protected int loadItems(Connection conn, int itemStartInclusive, int itemEndInclusive) {
         int k = 0;
         int randPct = 0;
         int len = 0;
@@ -162,7 +171,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
 
             Item item = new Item();
             int batchSize = 0;
-            for (int i = 1; i <= itemKount; i++) {
+            for (int i = itemStartInclusive; i <= itemEndInclusive; i++) {
 
                 item.i_id = i;
                 item.i_name = TPCCUtil.randomStr(TPCCUtil.randomNumber(14, 24,


### PR DESCRIPTION
TPC-C's ITEM table always has 100k items in it.
- The ITEM table was loaded with 1 thread.
- This PR loads ITEM with `workConf.getLoaderThreads()` many threads.

Tested on my machine with 12 loader threads, successfully loads exactly 100k items. (100k / 12 = 8333.333... items per thread).

Vague nostalgia working on this.