### PR TITLE
Small TPC-C datatype fixes and hacks.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/procedures/Delivery.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/procedures/Delivery.java
@@ -237,7 +237,7 @@ public class Delivery extends TPCCProcedure {
                 }
 
                 int idx = 1; // HACK: So that we can debug this query
-                delivUpdateCustBalDelivCnt.setBigDecimal(idx++, BigDecimal.valueOf(ol_total));
+                delivUpdateCustBalDelivCnt.setDouble(idx++, ol_total);
                 delivUpdateCustBalDelivCnt.setInt(idx++, w_id);
                 delivUpdateCustBalDelivCnt.setInt(idx++, d_id);
                 delivUpdateCustBalDelivCnt.setInt(idx, c_id);

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/procedures/Payment.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/procedures/Payment.java
@@ -26,7 +26,6 @@ import com.oltpbenchmark.benchmarks.tpcc.pojo.Customer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Random;
@@ -159,7 +158,7 @@ public class Payment extends TPCCProcedure {
             String w_street_1, w_street_2, w_city, w_state, w_zip, w_name;
             String d_street_1, d_street_2, d_city, d_state, d_zip, d_name;
 
-            payUpdateWhse.setBigDecimal(1, BigDecimal.valueOf(paymentAmount));
+            payUpdateWhse.setDouble(1, paymentAmount);
             payUpdateWhse.setInt(2, w_id);
             // MySQL reports deadlocks due to lock upgrades:
             // t1: read w_id = x; t2: update w_id = x; t1 update w_id = x
@@ -181,7 +180,7 @@ public class Payment extends TPCCProcedure {
                 w_name = rs.getString("W_NAME");
             }
 
-            payUpdateDist.setBigDecimal(1, BigDecimal.valueOf(paymentAmount));
+            payUpdateDist.setDouble(1, paymentAmount);
             payUpdateDist.setInt(2, w_id);
             payUpdateDist.setInt(3, districtID);
             result = payUpdateDist.executeUpdate();

--- a/src/main/java/com/oltpbenchmark/catalog/HSQLDBCatalog.java
+++ b/src/main/java/com/oltpbenchmark/catalog/HSQLDBCatalog.java
@@ -206,7 +206,6 @@ public class HSQLDBCatalog implements AbstractCatalog {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        System.out.println(ddlContents);
         // Extract and map the original table names to their uppercase versions.
         Map<String, String> originalTableNames = new HashMap<>();
         Pattern p = Pattern.compile("CREATE[\\s]+TABLE[\\s]+(.*?)[\\s]+", Pattern.CASE_INSENSITIVE);

--- a/src/main/resources/benchmarks/tpcc/ddl-cockroachdb.sql
+++ b/src/main/resources/benchmarks/tpcc/ddl-cockroachdb.sql
@@ -139,7 +139,7 @@ CREATE TABLE order_line (
     ol_delivery_d  timestamp     NULL DEFAULT NULL,
     ol_amount      decimal(6, 2) NOT NULL,
     ol_supply_w_id int           NOT NULL,
-    ol_quantity    int           NOT NULL,
+    ol_quantity    decimal(6, 2) NOT NULL,
     ol_dist_info   char(24)      NOT NULL,
     FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
     FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,

--- a/src/main/resources/benchmarks/tpcc/ddl-noisepage.sql
+++ b/src/main/resources/benchmarks/tpcc/ddl-noisepage.sql
@@ -139,7 +139,7 @@ CREATE TABLE order_line (
     ol_delivery_d  timestamp     DEFAULT NULL, /* NULL DEFAULT NULL, */
     ol_amount      decimal(6, 2) NOT NULL,
     ol_supply_w_id int           NOT NULL,
-    ol_quantity    int           NOT NULL,
+    ol_quantity    decimal(6,2)  NOT NULL,
     ol_dist_info   char(24)      NOT NULL,
     /* FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
     FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE, */

--- a/src/main/resources/benchmarks/tpcc/ddl-noisepage.sql
+++ b/src/main/resources/benchmarks/tpcc/ddl-noisepage.sql
@@ -17,8 +17,8 @@ CREATE TABLE warehouse (
     w_street_2 varchar(20)    NOT NULL,
     w_city     varchar(20)    NOT NULL,
     w_state    char(2)        NOT NULL,
-    w_zip      char(9)        NOT NULL /* ,
-    PRIMARY KEY (w_id) */
+    w_zip      char(9)        NOT NULL,
+    PRIMARY KEY (w_id)
 );
 
 CREATE TABLE item (
@@ -26,8 +26,8 @@ CREATE TABLE item (
     i_name  varchar(24)   NOT NULL,
     i_price decimal(5, 2) NOT NULL,
     i_data  varchar(50)   NOT NULL,
-    i_im_id int           NOT NULL /* ,
-    PRIMARY KEY (i_id) */
+    i_im_id int           NOT NULL,
+    PRIMARY KEY (i_id)
 );
 
 CREATE TABLE stock (
@@ -47,10 +47,10 @@ CREATE TABLE stock (
     s_dist_07    char(24)      NOT NULL,
     s_dist_08    char(24)      NOT NULL,
     s_dist_09    char(24)      NOT NULL,
-    s_dist_10    char(24)      NOT NULL /* ,
-    FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
-    FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE,
-    PRIMARY KEY (s_w_id, s_i_id) */
+    s_dist_10    char(24)      NOT NULL,
+    /* FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE, */
+    PRIMARY KEY (s_w_id, s_i_id)
 );
 
 CREATE TABLE district (
@@ -64,9 +64,9 @@ CREATE TABLE district (
     d_street_2  varchar(20)    NOT NULL,
     d_city      varchar(20)    NOT NULL,
     d_state     char(2)        NOT NULL,
-    d_zip       char(9)        NOT NULL /* ,
-    FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
-    PRIMARY KEY (d_w_id, d_id) */
+    d_zip       char(9)        NOT NULL,
+    /* FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE, */
+    PRIMARY KEY (d_w_id, d_id)
 );
 
 CREATE TABLE customer (
@@ -90,9 +90,9 @@ CREATE TABLE customer (
     c_phone        char(16)       NOT NULL,
     c_since        timestamp      NOT NULL, /* DEFAULT CURRENT_TIMESTAMP, */
     c_middle       char(2)        NOT NULL,
-    c_data         varchar(500)   NOT NULL /* ,
-    FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE,
-    PRIMARY KEY (c_w_id, c_d_id, c_id) */
+    c_data         varchar(500)   NOT NULL,
+    /* FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE, */
+    PRIMARY KEY (c_w_id, c_d_id, c_id)
 );
 
 CREATE TABLE history (
@@ -116,18 +116,18 @@ CREATE TABLE oorder (
     o_carrier_id int                DEFAULT NULL,
     o_ol_cnt     int       NOT NULL,
     o_all_local  int       NOT NULL,
-    o_entry_d    timestamp NOT NULL /* DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (o_w_id, o_d_id, o_id),
-    FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
+    o_entry_d    timestamp NOT NULL, /* DEFAULT CURRENT_TIMESTAMP, */
+    PRIMARY KEY (o_w_id, o_d_id, o_id)
+    /* FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
     UNIQUE (o_w_id, o_d_id, o_c_id, o_id) */
 );
 
 CREATE TABLE new_order (
     no_w_id int NOT NULL,
     no_d_id int NOT NULL,
-    no_o_id int NOT NULL /* ,
-    FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
-    PRIMARY KEY (no_w_id, no_d_id, no_o_id) */
+    no_o_id int NOT NULL,
+    /* FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE, */
+    PRIMARY KEY (no_w_id, no_d_id, no_o_id)
 );
 
 CREATE TABLE order_line (
@@ -140,11 +140,11 @@ CREATE TABLE order_line (
     ol_amount      decimal(6, 2) NOT NULL,
     ol_supply_w_id int           NOT NULL,
     ol_quantity    int           NOT NULL,
-    ol_dist_info   char(24)      NOT NULL /* ,
-    FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
-    FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,
-    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number) */
+    ol_dist_info   char(24)      NOT NULL,
+    /* FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE, */
+    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
 );
 
-CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first);
+CREATE INDEX idx_customer_name ON customer (c_w_id, c_d_id, c_last);
 CREATE INDEX idx_order ON oorder (o_w_id, o_d_id, o_c_id, o_id);

--- a/src/main/resources/benchmarks/tpcc/ddl-postgres.sql
+++ b/src/main/resources/benchmarks/tpcc/ddl-postgres.sql
@@ -139,7 +139,7 @@ CREATE TABLE order_line (
     ol_delivery_d  timestamp     NULL DEFAULT NULL,
     ol_amount      decimal(6, 2) NOT NULL,
     ol_supply_w_id int           NOT NULL,
-    ol_quantity    int           NOT NULL,
+    ol_quantity    decimal(6,2)  NOT NULL,
     ol_dist_info   char(24)      NOT NULL,
     FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
     FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,


### PR DESCRIPTION
- Nit: Remove vestigial print statement.
- Fix: TPC-C ol_quantity should be numeric(2).
- Hack: NoisePage doesn't support DECIMAL types unfortunately, and it appears that the JDBC driver is equally happy with Double -- so we're going to use Double for now.