### PR TITLE
TPC-H fixes.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q10.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q10.java
@@ -21,6 +21,7 @@ import com.oltpbenchmark.api.SQLStmt;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -57,7 +58,8 @@ public class Q10 extends GenericQuery {
                     + "c_address, "
                     + "c_comment "
                     + "order by "
-                    + "revenue desc"
+                    + "revenue desc "
+                    + "limit 20"
     );
 
     @Override
@@ -68,8 +70,8 @@ public class Q10 extends GenericQuery {
         String date = String.format("%d-%02d-01", year, month);
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
-        stmt.setString(1, date);
-        stmt.setString(2, date);
+        stmt.setDate(1, Date.valueOf(date));
+        stmt.setDate(2, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q12.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q12.java
@@ -23,6 +23,7 @@ import com.oltpbenchmark.benchmarks.tpch.util.TPCHUtil;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -78,8 +79,8 @@ public class Q12 extends GenericQuery {
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
         stmt.setString(1, shipMode1);
         stmt.setString(2, shipMode2);
-        stmt.setString(3, date);
-        stmt.setString(4, date);
+        stmt.setDate(3, Date.valueOf(date));
+        stmt.setDate(4, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q14.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q14.java
@@ -21,6 +21,7 @@ import com.oltpbenchmark.api.SQLStmt;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -50,8 +51,8 @@ public class Q14 extends GenericQuery {
         String date = String.format("%d-%02d-01", year, month);
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
-        stmt.setString(1, date);
-        stmt.setString(2, date);
+        stmt.setDate(1, Date.valueOf(date));
+        stmt.setDate(2, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q18.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q18.java
@@ -58,7 +58,8 @@ public class Q18 extends GenericQuery {
                     + "o_totalprice "
                     + "order by "
                     + "o_totalprice desc, "
-                    + "o_orderdate"
+                    + "o_orderdate "
+                    + "limit 100"
     );
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q2.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q2.java
@@ -71,7 +71,8 @@ public class Q2 extends GenericQuery {
                     + "s_acctbal desc, "
                     + "n_name, "
                     + "s_name, "
-                    + "p_partkey"
+                    + "p_partkey "
+                    + "limit 100"
     );
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q20.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q20.java
@@ -23,6 +23,7 @@ import com.oltpbenchmark.benchmarks.tpch.util.TPCHUtil;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -82,8 +83,8 @@ public class Q20 extends GenericQuery {
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
         stmt.setString(1, color);
-        stmt.setString(2, date);
-        stmt.setString(3, date);
+        stmt.setDate(2, Date.valueOf(date));
+        stmt.setDate(3, Date.valueOf(date));
         stmt.setString(4, nation);
         return stmt;
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q21.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q21.java
@@ -67,7 +67,8 @@ public class Q21 extends GenericQuery {
                     + "s_name "
                     + "order by "
                     + "numwait desc, "
-                    + "s_name"
+                    + "s_name "
+                    + "limit 100"
     );
 
     @Override

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q22.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q22.java
@@ -94,10 +94,10 @@ public class Q22 extends GenericQuery {
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
         for (int i = 0; i < 7; i++) {
-            stmt.setInt(1 + i, codes[i]);
+            stmt.setString(1 + i, String.valueOf(codes[i]));
         }
         for (int i = 0; i < 7; i++) {
-            stmt.setInt(8 + i, codes[i]);
+            stmt.setString(8 + i, String.valueOf(codes[i]));
         }
         return stmt;
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q3.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q3.java
@@ -23,6 +23,7 @@ import com.oltpbenchmark.benchmarks.tpch.util.TPCHUtil;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -50,7 +51,8 @@ public class Q3 extends GenericQuery {
                     + "o_shippriority "
                     + "order by "
                     + "revenue desc, "
-                    + "o_orderdate"
+                    + "o_orderdate "
+                    + "limit 10"
     );
 
     @Override
@@ -63,8 +65,8 @@ public class Q3 extends GenericQuery {
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
         stmt.setString(1, segment);
-        stmt.setString(2, date);
-        stmt.setString(3, date);
+        stmt.setDate(2, Date.valueOf(date));
+        stmt.setDate(3, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q4.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q4.java
@@ -21,6 +21,7 @@ import com.oltpbenchmark.api.SQLStmt;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -57,8 +58,8 @@ public class Q4 extends GenericQuery {
         String date = String.format("%d-%02d-01", year, month);
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
-        stmt.setString(1, date);
-        stmt.setString(2, date);
+        stmt.setDate(1, Date.valueOf(date));
+        stmt.setDate(2, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q5.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q5.java
@@ -23,6 +23,7 @@ import com.oltpbenchmark.benchmarks.tpch.util.TPCHUtil;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -64,8 +65,8 @@ public class Q5 extends GenericQuery {
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
         stmt.setString(1, region);
-        stmt.setString(2, date);
-        stmt.setString(3, date);
+        stmt.setDate(2, Date.valueOf(date));
+        stmt.setDate(3, Date.valueOf(date));
         return stmt;
     }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q6.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpch/procedures/Q6.java
@@ -21,6 +21,7 @@ import com.oltpbenchmark.api.SQLStmt;
 import com.oltpbenchmark.util.RandomGenerator;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -51,8 +52,8 @@ public class Q6 extends GenericQuery {
         int quantity = rand.number(24, 25);
 
         PreparedStatement stmt = this.getPreparedStatement(conn, query_stmt);
-        stmt.setString(1, date);
-        stmt.setString(2, date);
+        stmt.setDate(1, Date.valueOf(date));
+        stmt.setDate(2, Date.valueOf(date));
         stmt.setString(3, discount);
         stmt.setString(4, discount);
         stmt.setInt(5, quantity);

--- a/src/main/resources/benchmarks/tpch/dialect-cockroachdb.xml
+++ b/src/main/resources/benchmarks/tpch/dialect-cockroachdb.xml
@@ -9,7 +9,7 @@
 
         <procedure name="Q3">
             <statement name="query_stmt">
-                select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = ? and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate &lt; ?::date and l_shipdate > ?::date group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate
+                select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = ? and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate &lt; ?::date and l_shipdate > ?::date group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10
             </statement>
         </procedure>
 
@@ -39,7 +39,7 @@
 
         <procedure name="Q10">
             <statement name="query_stmt">
-                select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= ?::date and o_orderdate &lt; ?::date + interval '3' month and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc
+                select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= ?::date and o_orderdate &lt; ?::date + interval '3' month and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc limit 20
             </statement>
         </procedure>
 

--- a/src/main/resources/benchmarks/tpch/dialect-postgres.xml
+++ b/src/main/resources/benchmarks/tpch/dialect-postgres.xml
@@ -9,7 +9,7 @@
 
         <procedure name="Q3">
             <statement name="query_stmt">
-                select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = ? and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate &lt; ?::date and l_shipdate > ?::date group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate
+                select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = ? and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate &lt; ?::date and l_shipdate > ?::date group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10
             </statement>
         </procedure>
 
@@ -33,7 +33,7 @@
 
         <procedure name="Q10">
             <statement name="query_stmt">
-                select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= ?::date and o_orderdate &lt; ?::date + interval '3' month and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc
+                select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= ?::date and o_orderdate &lt; ?::date + interval '3' month and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc limit 20
             </statement>
         </procedure>
 


### PR DESCRIPTION
I thought I already did this in #362, however, apparently the TPC-H fixes are not in yet.

Specifically,

- TPC-H Q3 string should be date.
- TPC-H Q4 string should be date.
- TPC-H Q5 string should be date.
- TPC-H Q6 string should be date.
- TPC-H Q10 string should be date.
- TPC-H Q12 string should be date.
- TPC-H Q14 string should be date.
- TPC-H Q20 string should be date.
- TPC-H Q22 int should be string.
- TPC-H Q2 missing LIMIT.
- TPC-H Q3 missing LIMIT.
- TPC-H Q10 missing LIMIT.
- TPC-H Q18 missing LIMIT.
- TPC-H Q21 missing LIMIT.