### PR TITLE
Remove substring cast to int in PostgreSQL TPC-H dialect.

### DIFF
--- a/src/main/resources/benchmarks/tpch/dialect-postgres.xml
+++ b/src/main/resources/benchmarks/tpch/dialect-postgres.xml
@@ -62,7 +62,7 @@
         </procedure>
         <procedure name="Q22">
             <statement name="query_stmt">
-                select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal from ( select substring(c_phone from 1 for 2) as cntrycode, c_acctbal from customer where substring(c_phone from 1 for 2)::int in (?, ?, ?, ?, ?, ?, ?) and c_acctbal > ( select avg(c_acctbal) from customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2)::int in (?, ?, ?, ?, ?, ?, ?) ) and not exists ( select * from orders where o_custkey = c_custkey ) ) as custsale group by cntrycode order by cntrycode
+                select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal from ( select substring(c_phone from 1 for 2) as cntrycode, c_acctbal from customer where substring(c_phone from 1 for 2) in (?, ?, ?, ?, ?, ?, ?) and c_acctbal > ( select avg(c_acctbal) from customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in (?, ?, ?, ?, ?, ?, ?) ) and not exists ( select * from orders where o_custkey = c_custkey ) ) as custsale group by cntrycode order by cntrycode
             </statement>
         </procedure>
 


### PR DESCRIPTION
Missed this.