### PR TITLE
Add Wikipedia set check to prevent adding the same watchlist page again.

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaWorker.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/wikipedia/WikipediaWorker.java
@@ -33,10 +33,13 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class WikipediaWorker extends Worker<WikipediaBenchmark> {
     private static final Logger LOG = LoggerFactory.getLogger(WikipediaWorker.class);
 
+    private Set<Integer> addedWatchlistPages = new HashSet<>();
     private final int num_users;
     private final int num_pages;
 
@@ -75,6 +78,12 @@ public class WikipediaWorker extends Worker<WikipediaBenchmark> {
 
         // Figure out what page they're going to update
         int page_id = z_pages.nextInt();
+        if (procClass.equals(AddWatchList.class)) {
+            while (addedWatchlistPages.contains(page_id)) {
+                page_id = z_pages.nextInt();
+            }
+            addedWatchlistPages.add(page_id);
+        }
 
         String pageTitle = WikipediaUtil.generatePageTitle(this.rng(), page_id);
         int nameSpace = WikipediaUtil.generatePageNamespace(this.rng(), page_id);


### PR DESCRIPTION
I'm not sure exactly why this is an issue now.
Given the same (user id, page id), the rest is deterministic --
this was true before, this is true now.
It is possible that the issue simply never surfaced before.
In any case, this can be solved with a set for now.
A long-running Wikipedia benchmark which adds a lot of watchlist entries
may suffer in memory, but it looks like the default is biased heavily
towards not doing that.