### PR TITLE
Fix NoOp benchmark execution

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/noop/procedures/NoOp.java
+++ b/src/com/oltpbenchmark/benchmarks/noop/procedures/NoOp.java
@@ -50,11 +50,13 @@ public class NoOp extends Procedure {
         // exception here and check whether it is actually working
         // correctly.
         try {
-            ResultSet r = stmt.executeQuery();
-            while (r.next()) {
-                // Do nothing
-            } // WHILE
-            r.close();
+            if (stmt.execute()) {
+                ResultSet r = stmt.getResultSet();
+                while (r.next()) {
+                    // Do nothing
+                } // WHILE
+                r.close();
+            }
         } catch (Exception ex) {
             // This error should be something like "No results were returned by the query."
             if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
The benchmark always ran through the catch-block, because
stmt.executeQuery() expects a result. The single query ';' does not
return anything at all.

Now, the query is executed and if there is a result, than it is
processed as before.

Tested with PostgreSQL 13.

See also: #229